### PR TITLE
Disable Rack::Protection::JsonCsrf

### DIFF
--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -26,7 +26,10 @@ module Himari
   class App < Sinatra::Base
     set :root, File.expand_path(File.join(__dir__, '..', '..'))
 
-    set :protection, use: %i(authenticity_token), except: %i(remote_token)
+    # remote_token: disabled in favor of authenticity_token (more stricter)
+    # json_csrf: can be prevented using x-content-type-options:nosniff
+    set :protection, use: %i(authenticity_token), except: %i(remote_token json_csrf)
+
     set :logging, nil
 
     ProviderCandidate = Struct.new(:name, :button, :action, keyword_init: true)


### PR DESCRIPTION
AWS ALB seems to propagate user-agent originated request headers on its `/oauth2/idpresponse` to a request sent to OP's userinfo endpoint (what??). I confirmed the userinfo endpoint receives: `referer`, `sec-ch-*`, `sec-fetch-*`, `accept-language` and other headers.

[Rack::Protection::JsonCsrf][] checks when a request is coming from 3rd party origin (by `referer` and `origin` header) and prevent JSON response to be returned to protect from the attack known as JSON hijacking.

The attack works with script HTML element to load JSON document and capture with overridden prototype.

The attack is now mitigated by: using [`x-content-type-options: nosniff`][], and many additional efforts ([bugzil.la/376957][]) were done in 10+ years ago.

We can say it is safe in modern browsers thus disabling the protection.

[Rack::Protection::JsonCsrf]: https://github.com/sinatra/sinatra/blob/main/rack-protection/lib/rack/protection/json_csrf.rb
[`x-content-type-options: nosniff`]: https://fetch.spec.whatwg.org/#determine-nosniff
[bugzil.la/376957]: https://bugzilla.mozilla.org/show_bug.cgi?id=376957