### PR TITLE
Dynamic & metadata client registration, and own redirect_uri matching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   specs:
     himari (0.5.0)
       addressable
+      httpx
       omniauth (>= 2.0)
       openid_connect
       rack-oauth2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   specs:
     himari (0.5.0)
       addressable
+      concurrent-ruby
       httpx
       omniauth (>= 2.0)
       openid_connect

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ use(Himari::Middlewares::Client,
   secret_hash: '...', # sha384 hexdigest of secret
   # secret: '...' # or in cleartext
   redirect_uris: %w(https://app.example.net/oauth2/idpresponse),
+  # Entries are matched by simple string comparison. A Regexp entry is matched
+  # with #match? against the request redirect_uri instead, e.g.
+  #   redirect_uris: [%r{\Ahttps://app\.example\.net/oauth2/[^/]+\z}]
   # ignore_localhost_redirect_uri_port: true, # (default) allow any port for loopback
   #   redirect_uris (http/https on localhost, 127.0.0.1, [::1]) per RFC 8252 §7.3, so native
   #   apps using an ephemeral port match. Set false to require exact port matching.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ use(Himari::Middlewares::Client,
   secret_hash: '...', # sha384 hexdigest of secret
   # secret: '...' # or in cleartext
   redirect_uris: %w(https://app.example.net/oauth2/idpresponse),
+  # ignore_localhost_redirect_uri_port: true, # (default) allow any port for loopback
+  #   redirect_uris (http/https on localhost, 127.0.0.1, [::1]) per RFC 8252 §7.3, so native
+  #   apps using an ephemeral port match. Set false to require exact port matching.
 )
 
 # Generate claims from omniauth authentication result

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ run Himari::App
 ## Documentation
 
 - [docs/refresh-tokens.md](./docs/refresh-tokens.md): Enabling the refresh token grant and revalidating sessions on refresh
+- [docs/dynamic-client-registrations.md](./docs/dynamic-client-registrations.md): RFC 7591 Dynamic Client Registration — let clients register themselves at runtime
+- [docs/metadata-client-registrations.md](./docs/metadata-client-registrations.md): Client ID Metadata Document — accept an https URL `client_id` pointing to a hosted metadata document
 
 ## Usage
 

--- a/dev/config.ru
+++ b/dev/config.ru
@@ -83,6 +83,9 @@ use(
 # clients are stored in the configured storage and resolve through the same client lookup.
 use(Himari::Middlewares::DynamicClients)
 
+# Enable OAuth Client ID Metadata Document support (draft-ietf-oauth-client-id-metadata-document)
+use(Himari::Middlewares::MetadataClients)
+
 use(Himari::Middlewares::ClaimsRule, name: 'developer-initialize') do |context, decision|
   next decision.skip! unless context.initial?
   next decision.skip!("provider not in scope") unless context.provider == 'developer'

--- a/dev/config.ru
+++ b/dev/config.ru
@@ -79,6 +79,10 @@ use(
   preferred_key_group: nil,
 )
 
+# Enable RFC 7591 Dynamic Client Registration (POST /public/oidc/register). Registered
+# clients are stored in the configured storage and resolve through the same client lookup.
+use(Himari::Middlewares::DynamicClients)
+
 use(Himari::Middlewares::ClaimsRule, name: 'developer-initialize') do |context, decision|
   next decision.skip! unless context.initial?
   next decision.skip!("provider not in scope") unless context.provider == 'developer'

--- a/docs/dynamic-client-registrations.md
+++ b/docs/dynamic-client-registrations.md
@@ -43,6 +43,7 @@ That single line:
 ```ruby
 use(Himari::Middlewares::DynamicClients,
   registration_lifetime: 180 * 86400, # seconds a registration stays valid (default 180 days)
+  ignore_localhost_redirect_uri_port: true, # (default) relax loopback redirect_uri ports (below)
 )
 ```
 
@@ -148,7 +149,13 @@ lookup as `Himari::Middlewares::Client`, but:
   not desired.
 - **Secrets are write-once.** Only the SHA-384 hash is stored; a lost secret
   means re-registering.
-- **`redirect_uris` are matched exactly** at authorize time, as with static
-  clients.
+- **`redirect_uris` are matched by simple string comparison** at authorize
+  time, as with static clients. The one exception is loopback redirect URIs
+  (`http`/`https` on `localhost`, `127.0.0.1`, `[::1]`): when
+  `ignore_localhost_redirect_uri_port` is enabled (default) their port is
+  ignored, so a native app that obtains an ephemeral port at runtime can match
+  (RFC 8252 §7.3, draft-ietf-oauth-v2-1-15 §8.4.2). This is a deployment policy
+  set on the middleware, not a per-client metadata field; clients cannot request
+  it. Set it to `false` to require exact port matching.
 
 See [dev/config.ru](../dev/config.ru) for a working local configuration.

--- a/docs/dynamic-client-registrations.md
+++ b/docs/dynamic-client-registrations.md
@@ -1,0 +1,154 @@
+# Dynamic Client Registration (RFC 7591)
+
+Himari can let clients register themselves at runtime via
+[RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) OAuth 2.0 Dynamic Client
+Registration, instead of every client being declared statically with
+`Himari::Middlewares::Client` in `config.ru`.
+
+A client POSTs a JSON metadata document to the registration endpoint and
+receives a freshly minted `client_id` (and, for confidential clients, a
+one-time `client_secret`). The registration is persisted in the configured
+storage backend and resolves through the same client lookup the OIDC
+authorization and token endpoints already use.
+
+> **No registration access token.** Himari implements registration only — there
+> is no [RFC 7592](https://www.rfc-editor.org/rfc/rfc7592) configuration
+> endpoint, so there is no read/update/delete of a registration, and no
+> `registration_access_token` / `registration_client_uri` is issued. A
+> registration is opaque after creation and simply expires (see
+> [Lifetime](#lifetime)).
+
+## Enabling
+
+Add the middleware after `Himari::Middlewares::Config` (it reads `storage` from
+the config):
+
+```ruby
+use(Himari::Middlewares::DynamicClients)
+```
+
+That single line:
+
+1. Exposes the registration endpoint at **`POST /public/oidc/register`** (also
+   reachable at `/oidc/register`). When the middleware is absent both routes
+   return `404`.
+2. Advertises `registration_endpoint` in the discovery documents
+   (`/.well-known/openid-configuration` and
+   `/.well-known/oauth-authorization-server`).
+3. Appends a storage-backed client provider to the client chain, so registered
+   `client_id`s resolve at authorize/token time.
+
+### Options
+
+```ruby
+use(Himari::Middlewares::DynamicClients,
+  registration_lifetime: 180 * 86400, # seconds a registration stays valid (default 180 days)
+)
+```
+
+## Registering a client
+
+```
+POST /public/oidc/register
+Content-Type: application/json
+
+{
+  "redirect_uris": ["https://app.example.net/auth/callback"],
+  "client_name": "My App",
+  "token_endpoint_auth_method": "client_secret_basic"
+}
+```
+
+On success the endpoint returns `201 Created` with the RFC 7591 §3.2.1 client
+information response:
+
+```json
+{
+  "client_id": "g0K...24-byte-urlsafe...",
+  "client_id_issued_at": 1748400000,
+  "redirect_uris": ["https://app.example.net/auth/callback"],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "client_secret_basic",
+  "client_name": "My App",
+  "client_secret": "one-time-secret-...",
+  "client_secret_expires_at": 1763952000
+}
+```
+
+The `client_secret` is generated server-side and **only ever returned in this
+response** — only its SHA-384 hash is persisted, so it cannot be retrieved
+later. Store it when you register.
+
+### Supported metadata
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `redirect_uris` | — | **Required**, non-empty array. Each must be an absolute URI with a scheme, no fragment, ≤ 2000 chars. Up to 32 entries. The schemes `javascript`, `data`, `vbscript`, `file`, `blob` are rejected. |
+| `token_endpoint_auth_method` | `client_secret_basic` | One of `none`, `client_secret_basic`, `client_secret_post`. `none` makes the client public (no secret). |
+| `grant_types` | `["authorization_code"]` | Subset of `authorization_code`, `refresh_token`. |
+| `response_types` | `["code"]` | Only `code` is supported. Requesting `code` requires `authorization_code` in `grant_types`. |
+| `client_name` | — | Optional, ≤ 60 chars. |
+| `client_uri` | — | Optional; must be an absolute URI with scheme and host, ≤ 2000 chars. |
+| `scope` | — | Optional, stored and echoed back. |
+
+Unknown metadata fields are ignored.
+
+### Confidential vs. public clients
+
+- `token_endpoint_auth_method` other than `none` → **confidential**: a
+  `client_secret` is issued and required at the token endpoint.
+- `token_endpoint_auth_method: "none"` → **public**: no secret is issued, and
+  **PKCE is mandatory** (the authorization code is otherwise unbound). Use this
+  for SPAs, native, and CLI clients.
+
+### Errors
+
+Validation failures return `400` with an RFC 7591 §3.2.2 error body, e.g.:
+
+```json
+{ "error": "invalid_redirect_uri", "error_description": "redirect_uris is required and must be a non-empty array" }
+```
+
+The error codes used are `invalid_redirect_uri` and `invalid_client_metadata`.
+A non-POST request returns `405`, and a body that is not a JSON object returns
+`400 invalid_client_metadata`.
+
+## Lifetime
+
+Each registration carries an absolute expiry (`client_secret_expires_at`),
+`registration_lifetime` seconds after issuance (default 180 days). After that
+the client lookup treats it as unknown and the authorization/token endpoints
+reject it. There is no renewal — the client must register again.
+
+Expiry is enforced in two places so it holds regardless of backend: the storage
+provider filters out expired registrations on lookup (so Memory and Filesystem,
+which have no native TTL, still fail closed), and on DynamoDB the record also
+carries a TTL attribute for eventual cleanup.
+
+## How registered clients differ from static clients
+
+Registered clients flow through the exact same `client_provider.find(id:)`
+lookup as `Himari::Middlewares::Client`, but:
+
+- They have **no friendly name**. AuthorizationRules that key on
+  `context.client.name` will never match a dynamic client — design rules so the
+  default path covers (or explicitly denies) anonymous clients if you enable
+  registration on a sensitive deployment.
+- The registration record retains the registrant's IP / `REMOTE_ADDR` /
+  `X-Forwarded-For` for audit, but these are not exposed to rules.
+
+## Security notes
+
+- **Registration is unauthenticated.** Anyone who can reach
+  `/public/oidc/register` can mint a client. This is acceptable because clients
+  still cannot get tokens without passing your Authentication and Authorization
+  rules, but you should ensure those rules do not implicitly trust "any client".
+  Consider fronting the endpoint with network controls if open registration is
+  not desired.
+- **Secrets are write-once.** Only the SHA-384 hash is stored; a lost secret
+  means re-registering.
+- **`redirect_uris` are matched exactly** at authorize time, as with static
+  clients.
+
+See [dev/config.ru](../dev/config.ru) for a working local configuration.

--- a/docs/metadata-client-registrations.md
+++ b/docs/metadata-client-registrations.md
@@ -57,6 +57,10 @@ use(Himari::Middlewares::MetadataClients,
   cache_min_ttl: 60,
   cache_max_ttl: 86400,
   cache_default_ttl: 300,
+
+  # Approximate cap (bytes) on the total size of cached documents. When exceeded,
+  # the oldest entries are evicted until the total fits. Default 1 MiB.
+  cache_max_total_size: 1_048_576,
 )
 ```
 
@@ -127,6 +131,10 @@ response's `Cache-Control: max-age` or `Expires`, clamped to
 `[cache_min_ttl, cache_max_ttl]`; `no-store` / `no-cache` disables caching for
 that document. Errors and malformed documents are never cached. The cache and
 its HTTPX session live for the process lifetime, so they reset on redeploy.
+
+The cache is bounded by `cache_max_total_size`: it tracks the approximate total
+size of cached documents (by original JSON body bytes) and, once that budget is
+exceeded, evicts the oldest entries until the total fits again.
 
 ## SSRF considerations
 

--- a/docs/metadata-client-registrations.md
+++ b/docs/metadata-client-registrations.md
@@ -1,0 +1,144 @@
+# Client ID Metadata Document
+
+Himari can accept a `client_id` that is itself an **https URL** pointing to a
+JSON client metadata document, per the
+[OAuth Client ID Metadata Document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/)
+draft (`draft-ietf-oauth-client-id-metadata-document`). Instead of registering
+ahead of time (see [Dynamic Client Registration](./dynamic-client-registrations.md)),
+a client simply hosts its own metadata at a URL and uses that URL as its
+`client_id`. Himari fetches and validates the document on demand.
+
+This is well suited to decentralized clients that can publish a static document
+but cannot pre-register — e.g. the pattern popularized by AT Protocol /
+Bluesky.
+
+## Enabling
+
+Add the middleware after `Himari::Middlewares::Config`:
+
+```ruby
+use(Himari::Middlewares::MetadataClients)
+```
+
+That:
+
+1. Registers a client provider that resolves URL `client_id`s by fetching their
+   metadata document.
+2. Advertises `client_id_metadata_document_supported: true` in the discovery
+   documents.
+
+There is no new endpoint — the URL `client_id` is consumed directly at the
+authorization and token endpoints.
+
+### Options
+
+```ruby
+use(Himari::Middlewares::MetadataClients,
+  # Optional allowlist of acceptable client_id URLs. Empty (default) accepts any
+  # compliant https URL. Entries are String (exact match) or Regexp (=~).
+  allowed_client_ids: [%r{\Ahttps://[^/]+\.example\.com/}],
+
+  # Force PKCE for these clients. Default true; they are always public.
+  require_pkce: true,
+
+  # SSRF filtering. true (default) restricts fetches to https and blocks
+  # special-use IPs. A Hash is merged into the ssrf_filter plugin options.
+  # false disables filtering — only for an authorization server on loopback.
+  ssrf: true,
+
+  # Fetch tuning.
+  user_agent: 'Himari-OauthClientMetadataFetch/... (+https://github.com/sorah/himari)',
+  http_timeout: { connect_timeout: 5, request_timeout: 10 },
+  max_response_size: 5120, # bytes; documents larger than this are rejected
+
+  # Cache bounds (seconds). The document's Cache-Control/Expires is honored
+  # within [cache_min_ttl, cache_max_ttl]; cache_default_ttl applies when the
+  # response gives no usable directive.
+  cache_min_ttl: 60,
+  cache_max_ttl: 86400,
+  cache_default_ttl: 300,
+)
+```
+
+## How a client uses it
+
+The client hosts a JSON document at a URL and uses that URL as its `client_id`:
+
+```
+GET https://app.example.com/oauth-client.json
+Content-Type: application/json
+
+{
+  "client_id": "https://app.example.com/oauth-client.json",
+  "client_name": "My App",
+  "redirect_uris": ["https://app.example.com/auth/callback"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+Then it begins an ordinary authorization-code + PKCE flow with
+`client_id=https://app.example.com/oauth-client.json`. Himari fetches the
+document and treats the client as a public client.
+
+## Validation rules
+
+For a `client_id` to be accepted:
+
+**As a URL** (checked before any fetch):
+
+- Scheme must be `https`.
+- No fragment, no userinfo (`user:pass@`).
+- Must have a non-empty path with no `.` / `..` path segments.
+- Must match `allowed_client_ids` if that option is set.
+
+**The fetch** (the draft forbids following redirects):
+
+- Only a `200` response is accepted — any 3xx/4xx/5xx is an error.
+- `Content-Type` must be `application/json` (or `*+json`).
+- Body must not exceed `max_response_size` (by `Content-Length` and actual
+  bytes).
+
+**The document:**
+
+- Must be a JSON object whose `client_id` **exactly equals** the request URL.
+- Must **not** contain `client_secret` / `client_secret_expires_at` (these
+  clients are always public).
+- `token_endpoint_auth_method`, if present, must be `none`.
+- `redirect_uris` is validated exactly as in
+  [Dynamic Client Registration](./dynamic-client-registrations.md#supported-metadata)
+  (absolute URIs, no fragment, length and scheme limits).
+
+The client is always presented as **public**, so PKCE is required (unless you
+explicitly set `require_pkce: false`).
+
+## Failure behavior
+
+The provider **fails closed**: any transport error, SSRF rejection, non-200
+response, oversized body, wrong content type, malformed JSON, or failed
+validation results in the `client_id` being treated as *unknown* (the
+authorization endpoint returns "unknown client") rather than raising. Rejections
+are logged with the reason.
+
+## Caching
+
+Successfully fetched and validated documents are cached in-memory by the
+provider for connection-less reuse across requests. The TTL honors the
+response's `Cache-Control: max-age` or `Expires`, clamped to
+`[cache_min_ttl, cache_max_ttl]`; `no-store` / `no-cache` disables caching for
+that document. Errors and malformed documents are never cached. The cache and
+its HTTPX session live for the process lifetime, so they reset on redeploy.
+
+## SSRF considerations
+
+Because Himari fetches an attacker-influenced URL, SSRF filtering is **on by
+default**: fetches are restricted to `https` and the `ssrf_filter` HTTPX plugin
+blocks special-use / private IP ranges. Redirects are never followed.
+
+- Tighten or extend it by passing a Hash (merged into the plugin options).
+- Set `ssrf: false` **only** when running the authorization server on a
+  loopback address for local testing, where the filter would otherwise block
+  your own test target.
+- Combine with `allowed_client_ids` to restrict which hosts may serve client
+  metadata at all.
+
+See [dev/config.ru](../dev/config.ru) for a commented configuration example.

--- a/docs/metadata-client-registrations.md
+++ b/docs/metadata-client-registrations.md
@@ -41,6 +41,11 @@ use(Himari::Middlewares::MetadataClients,
   # Force PKCE for these clients. Default true; they are always public.
   require_pkce: true,
 
+  # Relax the port of loopback redirect_uris (http/https on localhost, 127.0.0.1,
+  # [::1]) when matching at the authorization endpoint, so native apps using an
+  # ephemeral port match (RFC 8252 §7.3). Default true; set false for exact ports.
+  ignore_localhost_redirect_uri_port: true,
+
   # SSRF filtering. true (default) restricts fetches to https and blocks
   # special-use IPs. A Hash is merged into the ssrf_filter plugin options.
   # false disables filtering — only for an authorization server on loopback.

--- a/docs/metadata-client-registrations.md
+++ b/docs/metadata-client-registrations.md
@@ -48,7 +48,7 @@ use(Himari::Middlewares::MetadataClients,
 
   # Fetch tuning.
   user_agent: 'Himari-OauthClientMetadataFetch/... (+https://github.com/sorah/himari)',
-  http_timeout: { connect_timeout: 5, request_timeout: 10 },
+  http_timeout: { connect_timeout: 5, request_timeout: 10, read_timeout: 10 },
   max_response_size: 5120, # bytes; documents larger than this are rejected
 
   # Cache bounds (seconds). The document's Cache-Control/Expires is honored
@@ -99,8 +99,10 @@ For a `client_id` to be accepted:
 
 - Only a `200` response is accepted — any 3xx/4xx/5xx is an error.
 - `Content-Type` must be `application/json` (or `*+json`).
-- Body must not exceed `max_response_size` (by `Content-Length` and actual
-  bytes).
+- Body must not exceed `max_response_size`. The response is **streamed** and the
+  read is aborted as soon as the cap is exceeded (a `Content-Length` header over
+  the cap is rejected up front), so a host that omits `Content-Length` cannot
+  make Himari buffer an unbounded body.
 
 **The document:**
 

--- a/himari/himari.gemspec
+++ b/himari/himari.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sinatra", '>= 3.0'
 
   spec.add_dependency 'addressable'
+  spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'httpx'
 
   spec.add_dependency "openid_connect"

--- a/himari/himari.gemspec
+++ b/himari/himari.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sinatra", '>= 3.0'
 
   spec.add_dependency 'addressable'
+  spec.add_dependency 'httpx'
 
   spec.add_dependency "openid_connect"
   spec.add_dependency "rack-oauth2"

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -255,13 +255,17 @@ module Himari
       delete(path, &register_ep)
     end
 
-    get '/.well-known/openid-configuration' do
+    metadata_ep = proc do
       Himari::Services::OidcProviderMetadataEndpoint.new(
         signing_key_provider: signing_key_provider,
         issuer: config.issuer,
         registration_endpoint: dynamic_clients_enabled? ? "#{config.issuer}/public/oidc/register" : nil,
       ).call(env)
     end
+    # OpenID Connect Discovery 1.0
+    get '/.well-known/openid-configuration', &metadata_ep
+    # RFC 8414 OAuth 2.0 Authorization Server Metadata
+    get '/.well-known/oauth-authorization-server', &metadata_ep
 
     omniauth_callback = proc do
       authhash = request.env['omniauth.auth']

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -17,10 +17,12 @@ require 'himari/session_data'
 require 'himari/middlewares/client'
 require 'himari/middlewares/config'
 require 'himari/middlewares/signing_key'
+require 'himari/middlewares/dynamic_clients'
 
 require 'himari/services/downstream_authorization'
 require 'himari/services/upstream_authentication'
 
+require 'himari/services/client_registration_endpoint'
 require 'himari/services/jwks_endpoint'
 require 'himari/services/oidc_authorization_endpoint'
 require 'himari/services/oidc_provider_metadata_endpoint'
@@ -73,6 +75,10 @@ module Himari
 
       def client_provider
         Himari::ProviderChain.new(request.env[Himari::Middlewares::Client::RACK_KEY] || [])
+      end
+
+      def dynamic_clients_enabled?
+        request.env.key?(Himari::Middlewares::DynamicClients::RACK_KEY)
       end
 
       def known_providers
@@ -227,10 +233,33 @@ module Himari
     get '/jwks', &jwks_ep
     get '/public/jwks', &jwks_ep
 
+    # RFC 7591 Dynamic Client Registration. Enabled by presence of the DynamicClients
+    # middleware; the route always exists but 404s when the feature is off.
+    register_ep = proc do
+      next halt 404, 'not found' unless dynamic_clients_enabled?
+
+      Himari::Services::ClientRegistrationEndpoint.new(
+        storage: config.storage,
+        registration_lifetime: request.env[Himari::Middlewares::DynamicClients::RACK_KEY].registration_lifetime,
+        logger: logger,
+      ).call(env)
+    end
+    post '/oidc/register', &register_ep
+    post '/public/oidc/register', &register_ep
+    # Wire the non-POST verbs too so they reach the endpoint, which answers 405 (RFC 7591 only
+    # defines POST). Without these Sinatra would 404 a GET, masking the method error.
+    %w(/oidc/register /public/oidc/register).each do |path|
+      get(path, &register_ep)
+      put(path, &register_ep)
+      patch(path, &register_ep)
+      delete(path, &register_ep)
+    end
+
     get '/.well-known/openid-configuration' do
       Himari::Services::OidcProviderMetadataEndpoint.new(
         signing_key_provider: signing_key_provider,
         issuer: config.issuer,
+        registration_endpoint: dynamic_clients_enabled? ? "#{config.issuer}/public/oidc/register" : nil,
       ).call(env)
     end
 

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -18,6 +18,7 @@ require 'himari/middlewares/client'
 require 'himari/middlewares/config'
 require 'himari/middlewares/signing_key'
 require 'himari/middlewares/dynamic_clients'
+require 'himari/middlewares/metadata_clients'
 
 require 'himari/services/downstream_authorization'
 require 'himari/services/upstream_authentication'
@@ -79,6 +80,10 @@ module Himari
 
       def dynamic_clients_enabled?
         request.env.key?(Himari::Middlewares::DynamicClients::RACK_KEY)
+      end
+
+      def metadata_clients_enabled?
+        request.env.key?(Himari::Middlewares::MetadataClients::RACK_KEY)
       end
 
       def known_providers
@@ -260,6 +265,7 @@ module Himari
         signing_key_provider: signing_key_provider,
         issuer: config.issuer,
         registration_endpoint: dynamic_clients_enabled? ? "#{config.issuer}/public/oidc/register" : nil,
+        client_id_metadata_document_supported: metadata_clients_enabled?,
       ).call(env)
     end
     # OpenID Connect Discovery 1.0

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -246,6 +246,7 @@ module Himari
       Himari::Services::ClientRegistrationEndpoint.new(
         storage: config.storage,
         registration_lifetime: request.env[Himari::Middlewares::DynamicClients::RACK_KEY].registration_lifetime,
+        ignore_localhost_redirect_uri_port: request.env[Himari::Middlewares::DynamicClients::RACK_KEY].ignore_localhost_redirect_uri_port,
         logger: logger,
       ).call(env)
     end

--- a/himari/lib/himari/client_registration.rb
+++ b/himari/lib/himari/client_registration.rb
@@ -4,7 +4,7 @@ require 'digest/sha2'
 
 module Himari
   class ClientRegistration
-    def initialize(name:, id:, secret: nil, secret_hash: nil, redirect_uris:, preferred_key_group: nil, require_pkce: false)
+    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true)
       @name = name
       @id = id
       @secret = secret
@@ -12,18 +12,25 @@ module Himari
       @redirect_uris = redirect_uris
       @preferred_key_group = preferred_key_group
       @require_pkce = require_pkce
+      @confidential = confidential
 
       raise ArgumentError, "name starts with '_' is reserved" if @name&.start_with?('_')
-      raise ArgumentError, "either secret or secret_hash must be present" if !@secret && !@secret_hash
+      raise ArgumentError, "either secret or secret_hash must be present" if confidential && !@secret && !@secret_hash
     end
 
     attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce
+
+    def confidential?
+      @confidential
+    end
 
     def secret_hash
       @secret_hash ||= Digest::SHA384.hexdigest(secret)
     end
 
     def match_secret?(given_secret)
+      return false unless confidential? && given_secret
+
       if @secret
         Rack::Utils.secure_compare(@secret, given_secret)
       else

--- a/himari/lib/himari/client_registration.rb
+++ b/himari/lib/himari/client_registration.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require 'digest/sha2'
+require 'addressable/uri'
 
 module Himari
   class ClientRegistration
-    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true)
+    # Loopback hosts whose redirect_uri port may be relaxed (RFC 8252 §7.3,
+    # draft-ietf-oauth-v2-1-15 §8.4.2). Addressable returns IPv6 hosts bracketed.
+    LOOPBACK_HOSTS = %w[127.0.0.1 [::1] localhost].freeze
+
+    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true, ignore_localhost_redirect_uri_port: true)
       @name = name
       @id = id
       @secret = secret
@@ -13,12 +18,13 @@ module Himari
       @preferred_key_group = preferred_key_group
       @require_pkce = require_pkce
       @confidential = confidential
+      @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
 
       raise ArgumentError, "name starts with '_' is reserved" if @name&.start_with?('_')
       raise ArgumentError, "either secret or secret_hash must be present" if confidential && !@secret && !@secret_hash
     end
 
-    attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce
+    attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce, :ignore_localhost_redirect_uri_port
 
     def confidential?
       @confidential
@@ -39,6 +45,16 @@ module Himari
       end
     end
 
+    # True when one of the registered redirect_uris covers the given (request) redirect_uri.
+    # draft-ietf-oauth-v2-1-15 §4.1.3 / RFC 3986 §6.2.1: simple (exact) string comparison, with the
+    # loopback-port exception of RFC 8252 §7.3 / draft-v2-1 §8.4.2 applied when enabled.
+    def redirect_uri_covers?(given)
+      given = given.to_s
+      return false if given.empty?
+
+      redirect_uris.any? { |registered| redirect_uri_match?(registered.to_s, given) }
+    end
+
     def as_log
       {name: name, id: id}
     end
@@ -53,6 +69,30 @@ module Himari
       end
 
       result
+    end
+
+    private def redirect_uri_match?(registered, given)
+      return true if registered == given
+      return false unless ignore_localhost_redirect_uri_port
+
+      reg = loopback_uri(registered) or return false
+      giv = loopback_uri(given) or return false
+
+      # Port is intentionally ignored to allow ephemeral loopback ports; fragments are
+      # rejected at registration time, so loopback_uri requires their absence here too.
+      reg.scheme == giv.scheme && reg.host == giv.host && reg.path == giv.path && reg.query == giv.query
+    end
+
+    private def loopback_uri(str)
+      uri = begin
+        Addressable::URI.parse(str)
+      rescue Addressable::URI::InvalidURIError
+        nil
+      end
+      return unless uri && LOOPBACK_HOSTS.include?(uri.host)
+      return if uri.fragment
+
+      uri
     end
   end
 end

--- a/himari/lib/himari/client_registration.rb
+++ b/himari/lib/himari/client_registration.rb
@@ -47,12 +47,13 @@ module Himari
 
     # True when one of the registered redirect_uris covers the given (request) redirect_uri.
     # draft-ietf-oauth-v2-1-15 §4.1.3 / RFC 3986 §6.2.1: simple (exact) string comparison, with the
-    # loopback-port exception of RFC 8252 §7.3 / draft-v2-1 §8.4.2 applied when enabled.
+    # loopback-port exception of RFC 8252 §7.3 / draft-v2-1 §8.4.2 applied when enabled. A registered
+    # entry may also be a Regexp (operator-supplied via static config), matched against the request URI.
     def redirect_uri_covers?(given)
       given = given.to_s
       return false if given.empty?
 
-      redirect_uris.any? { |registered| redirect_uri_match?(registered.to_s, given) }
+      redirect_uris.any? { |registered| redirect_uri_match?(registered, given) }
     end
 
     def as_log
@@ -72,6 +73,9 @@ module Himari
     end
 
     private def redirect_uri_match?(registered, given)
+      return registered.match?(given) if registered.is_a?(Regexp)
+
+      registered = registered.to_s
       return true if registered == given
       return false unless ignore_localhost_redirect_uri_port
 

--- a/himari/lib/himari/dynamic_client_registration.rb
+++ b/himari/lib/himari/dynamic_client_registration.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'digest/sha2'
+require 'securerandom'
+require 'addressable/uri'
+require 'himari/client_registration'
+
+module Himari
+  # A client created at runtime via RFC 7591 Dynamic Client Registration, persisted in
+  # storage. This is purely a storage/registration record: the registration endpoint
+  # interacts with it directly, while the OIDC endpoints only ever see the plain
+  # ClientRegistration produced by #to_client_registration at the provider layer.
+  class DynamicClientRegistration
+    # Default registration lifetime; overridable per deployment via Middlewares::DynamicClients.
+    REGISTRATION_LIFETIME = 180 * 86400
+
+    SUPPORTED_GRANT_TYPES = %w(authorization_code refresh_token).freeze
+    SUPPORTED_RESPONSE_TYPES = %w(code).freeze
+    SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = %w(none client_secret_basic client_secret_post).freeze
+
+    DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD = 'client_secret_basic'
+
+    MAX_REDIRECT_URIS = 32
+    MAX_URI_LENGTH = 2000
+    MAX_CLIENT_NAME_LENGTH = 60
+    DANGEROUS_REDIRECT_URI_SCHEMES = %w(javascript data vbscript file blob).freeze
+
+    # Raised on invalid client metadata. error_code maps to an RFC 7591 §3.2.2 error code.
+    class ValidationError < StandardError
+      def initialize(error_code, message)
+        @error_code = error_code
+        super(message)
+      end
+
+      attr_reader :error_code
+    end
+
+    # Build and validate a registration from RFC 7591 client metadata.
+    #
+    # @param metadata [Hash] parsed client metadata (symbolized keys) from the request body
+    # @return [DynamicClientRegistration]
+    def self.register(metadata:, registration_ip: nil, registration_remote_addr: nil, registration_x_forwarded_for: nil, lifetime: REGISTRATION_LIFETIME, now: Time.now)
+      raise ValidationError.new(:invalid_client_metadata, 'request body must be a JSON object') unless metadata.is_a?(Hash)
+
+      auth_method = metadata.fetch(:token_endpoint_auth_method, DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD).to_s
+      unless SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS.include?(auth_method)
+        raise ValidationError.new(:invalid_client_metadata, "unsupported token_endpoint_auth_method: #{auth_method}")
+      end
+
+      grant_types = Array(metadata[:grant_types] || %w(authorization_code)).map(&:to_s)
+      unless (grant_types - SUPPORTED_GRANT_TYPES).empty?
+        raise ValidationError.new(:invalid_client_metadata, "unsupported grant_types: #{(grant_types - SUPPORTED_GRANT_TYPES).join(",")}")
+      end
+
+      response_types = Array(metadata[:response_types] || %w(code)).map(&:to_s)
+      unless (response_types - SUPPORTED_RESPONSE_TYPES).empty?
+        raise ValidationError.new(:invalid_client_metadata, "unsupported response_types: #{(response_types - SUPPORTED_RESPONSE_TYPES).join(",")}")
+      end
+
+      if response_types.include?('code') && !grant_types.include?('authorization_code')
+        raise ValidationError.new(:invalid_client_metadata, 'response_type "code" requires grant_type "authorization_code"')
+      end
+
+      redirect_uris = validate_redirect_uris(metadata[:redirect_uris])
+
+      client_name = metadata[:client_name]&.to_s
+      if client_name && client_name.length > MAX_CLIENT_NAME_LENGTH
+        raise ValidationError.new(:invalid_client_metadata, "client_name must not exceed #{MAX_CLIENT_NAME_LENGTH} characters")
+      end
+
+      client_uri = validate_client_uri(metadata[:client_uri])
+
+      issued_at = now.to_i
+      secret = auth_method == 'none' ? nil : SecureRandom.urlsafe_base64(48)
+
+      new(
+        id: SecureRandom.urlsafe_base64(24),
+        redirect_uris: redirect_uris,
+        token_endpoint_auth_method: auth_method,
+        grant_types: grant_types,
+        response_types: response_types,
+        client_name: client_name,
+        client_uri: client_uri,
+        scope: metadata[:scope]&.to_s,
+        secret: secret,
+        secret_hash: secret && Digest::SHA384.hexdigest(secret),
+        client_id_issued_at: issued_at,
+        expiry: issued_at + lifetime,
+        registration_ip: registration_ip,
+        registration_remote_addr: registration_remote_addr,
+        registration_x_forwarded_for: registration_x_forwarded_for,
+      )
+    end
+
+    def self.validate_redirect_uris(given)
+      raise ValidationError.new(:invalid_redirect_uri, 'redirect_uris is required and must be a non-empty array') unless given.is_a?(Array) && !given.empty?
+      raise ValidationError.new(:invalid_redirect_uri, "redirect_uris must not exceed #{MAX_REDIRECT_URIS} entries") if given.size > MAX_REDIRECT_URIS
+
+      given.map do |uri|
+        str = uri.to_s
+        parsed = begin
+          Addressable::URI.parse(str)
+        rescue Addressable::URI::InvalidURIError
+          nil
+        end
+        raise ValidationError.new(:invalid_redirect_uri, "redirect_uri must not exceed #{MAX_URI_LENGTH} characters") if str.length > MAX_URI_LENGTH
+        raise ValidationError.new(:invalid_redirect_uri, "invalid redirect_uri: #{str}") unless parsed&.scheme
+        raise ValidationError.new(:invalid_redirect_uri, "redirect_uri must not contain a fragment: #{str}") if parsed.fragment
+        raise ValidationError.new(:invalid_redirect_uri, "redirect_uri scheme not allowed: #{str}") if DANGEROUS_REDIRECT_URI_SCHEMES.include?(parsed.scheme.downcase)
+
+        str
+      end
+    end
+
+    def self.validate_client_uri(given)
+      return if given.nil?
+
+      str = given.to_s
+      raise ValidationError.new(:invalid_client_metadata, "client_uri must not exceed #{MAX_URI_LENGTH} characters") if str.length > MAX_URI_LENGTH
+
+      parsed = begin
+        Addressable::URI.parse(str)
+      rescue Addressable::URI::InvalidURIError
+        nil
+      end
+      raise ValidationError.new(:invalid_client_metadata, "invalid client_uri: #{str}") unless parsed&.scheme && parsed.host
+
+      str
+    end
+
+    def self.from_json(hash)
+      attrs = hash.dup
+      attrs.delete(:ttl)
+      new(**attrs)
+    end
+
+    def initialize(id:, redirect_uris:, token_endpoint_auth_method:, grant_types:, response_types:, client_id_issued_at:, expiry:, secret: nil, secret_hash: nil, client_name: nil, client_uri: nil, scope: nil, preferred_key_group: nil, registration_ip: nil, registration_remote_addr: nil, registration_x_forwarded_for: nil)
+      @id = id
+      @redirect_uris = redirect_uris
+      @token_endpoint_auth_method = token_endpoint_auth_method
+      @grant_types = grant_types
+      @response_types = response_types
+      @client_id_issued_at = client_id_issued_at
+      @expiry = expiry
+      @secret = secret
+      @secret_hash = secret_hash
+      @client_name = client_name
+      @client_uri = client_uri
+      @scope = scope
+      @preferred_key_group = preferred_key_group
+      @registration_ip = registration_ip
+      @registration_remote_addr = registration_remote_addr
+      @registration_x_forwarded_for = registration_x_forwarded_for
+    end
+
+    attr_reader :id, :redirect_uris, :token_endpoint_auth_method, :grant_types, :response_types,
+      :client_id_issued_at, :expiry, :secret, :secret_hash, :client_name, :client_uri, :scope,
+      :preferred_key_group, :registration_ip, :registration_remote_addr, :registration_x_forwarded_for
+
+    def confidential?
+      token_endpoint_auth_method != 'none'
+    end
+
+    # Public clients have no secret to bind the authorization code, so PKCE is mandatory.
+    def require_pkce
+      !confidential?
+    end
+
+    def active?(now = Time.now)
+      expiry > now.to_i
+    end
+
+    # The client object the OIDC authorization/token endpoints consume. Dynamic records carry
+    # no name (so operator rules keyed on name never match them) and pass through the secret
+    # hash only for confidential clients.
+    def to_client_registration
+      ClientRegistration.new(
+        id: id,
+        redirect_uris: redirect_uris,
+        secret_hash: confidential? ? secret_hash : nil,
+        preferred_key_group: preferred_key_group,
+        require_pkce: require_pkce,
+        confidential: confidential?,
+      )
+    end
+
+    def as_log
+      {id: id, token_endpoint_auth_method: token_endpoint_auth_method, dynamic: true}
+    end
+
+    def as_json
+      {
+        id: id,
+        secret_hash: secret_hash,
+        redirect_uris: redirect_uris,
+        grant_types: grant_types,
+        response_types: response_types,
+        token_endpoint_auth_method: token_endpoint_auth_method,
+        client_name: client_name,
+        client_uri: client_uri,
+        scope: scope,
+        preferred_key_group: preferred_key_group,
+        client_id_issued_at: client_id_issued_at,
+        expiry: expiry,
+        ttl: expiry,
+        registration_ip: registration_ip,
+        registration_remote_addr: registration_remote_addr,
+        registration_x_forwarded_for: registration_x_forwarded_for,
+      }
+    end
+
+    # RFC 7591 §3.2.1 client information response. Includes client_secret only when freshly
+    # generated (the plaintext is never persisted, so it is available only right after register).
+    def registration_response
+      response = {
+        client_id: id,
+        client_id_issued_at: client_id_issued_at,
+        redirect_uris: redirect_uris,
+        grant_types: grant_types,
+        response_types: response_types,
+        token_endpoint_auth_method: token_endpoint_auth_method,
+        client_name: client_name,
+        client_uri: client_uri,
+        scope: scope,
+      }.compact
+
+      if confidential? && secret
+        response[:client_secret] = secret
+        response[:client_secret_expires_at] = expiry
+      end
+
+      response
+    end
+  end
+end

--- a/himari/lib/himari/dynamic_client_registration.rb
+++ b/himari/lib/himari/dynamic_client_registration.rb
@@ -185,7 +185,19 @@ module Himari
     end
 
     def as_log
-      {id: id, token_endpoint_auth_method: token_endpoint_auth_method, dynamic: true}
+      {
+        id: id,
+        token_endpoint_auth_method: token_endpoint_auth_method,
+        redirect_uris: redirect_uris,
+        grant_types: grant_types,
+        response_types: response_types,
+        client_name: client_name,
+        client_uri: client_uri,
+        scope: scope,
+        client_id_issued_at: client_id_issued_at,
+        expiry: expiry,
+        dynamic: true,
+      }
     end
 
     def as_json

--- a/himari/lib/himari/dynamic_client_registration.rb
+++ b/himari/lib/himari/dynamic_client_registration.rb
@@ -39,7 +39,7 @@ module Himari
     #
     # @param metadata [Hash] parsed client metadata (symbolized keys) from the request body
     # @return [DynamicClientRegistration]
-    def self.register(metadata:, registration_ip: nil, registration_remote_addr: nil, registration_x_forwarded_for: nil, lifetime: REGISTRATION_LIFETIME, now: Time.now)
+    def self.register(metadata:, registration_ip: nil, registration_remote_addr: nil, registration_x_forwarded_for: nil, lifetime: REGISTRATION_LIFETIME, ignore_localhost_redirect_uri_port: true, now: Time.now)
       raise ValidationError.new(:invalid_client_metadata, 'request body must be a JSON object') unless metadata.is_a?(Hash)
 
       auth_method = metadata.fetch(:token_endpoint_auth_method, DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD).to_s
@@ -89,6 +89,7 @@ module Himari
         registration_ip: registration_ip,
         registration_remote_addr: registration_remote_addr,
         registration_x_forwarded_for: registration_x_forwarded_for,
+        ignore_localhost_redirect_uri_port: ignore_localhost_redirect_uri_port,
       )
     end
 
@@ -134,7 +135,7 @@ module Himari
       new(**attrs)
     end
 
-    def initialize(id:, redirect_uris:, token_endpoint_auth_method:, grant_types:, response_types:, client_id_issued_at:, expiry:, secret: nil, secret_hash: nil, client_name: nil, client_uri: nil, scope: nil, preferred_key_group: nil, registration_ip: nil, registration_remote_addr: nil, registration_x_forwarded_for: nil)
+    def initialize(id:, redirect_uris:, token_endpoint_auth_method:, grant_types:, response_types:, client_id_issued_at:, expiry:, secret: nil, secret_hash: nil, client_name: nil, client_uri: nil, scope: nil, preferred_key_group: nil, registration_ip: nil, registration_remote_addr: nil, registration_x_forwarded_for: nil, ignore_localhost_redirect_uri_port: true)
       @id = id
       @redirect_uris = redirect_uris
       @token_endpoint_auth_method = token_endpoint_auth_method
@@ -151,11 +152,13 @@ module Himari
       @registration_ip = registration_ip
       @registration_remote_addr = registration_remote_addr
       @registration_x_forwarded_for = registration_x_forwarded_for
+      @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
     end
 
     attr_reader :id, :redirect_uris, :token_endpoint_auth_method, :grant_types, :response_types,
       :client_id_issued_at, :expiry, :secret, :secret_hash, :client_name, :client_uri, :scope,
-      :preferred_key_group, :registration_ip, :registration_remote_addr, :registration_x_forwarded_for
+      :preferred_key_group, :registration_ip, :registration_remote_addr, :registration_x_forwarded_for,
+      :ignore_localhost_redirect_uri_port
 
     def confidential?
       token_endpoint_auth_method != 'none'
@@ -181,6 +184,7 @@ module Himari
         preferred_key_group: preferred_key_group,
         require_pkce: require_pkce,
         confidential: confidential?,
+        ignore_localhost_redirect_uri_port: ignore_localhost_redirect_uri_port,
       )
     end
 
@@ -218,6 +222,7 @@ module Himari
         registration_ip: registration_ip,
         registration_remote_addr: registration_remote_addr,
         registration_x_forwarded_for: registration_x_forwarded_for,
+        ignore_localhost_redirect_uri_port: ignore_localhost_redirect_uri_port,
       }
     end
 

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -33,11 +33,13 @@ module Himari
 
       # @param session [HTTPX::Session] persistent, SSRF-filtered session (built by the middleware)
       # @param allowed_client_ids [Array<String, Regexp>] empty = allow any compliant https URL
-      def initialize(session:, allowed_client_ids: [], require_pkce: true, max_response_size: 5120,
+      def initialize(session:, allowed_client_ids: [], require_pkce: true, ignore_localhost_redirect_uri_port: true,
+        max_response_size: 5120,
         cache_min_ttl: 60, cache_max_ttl: 86400, cache_default_ttl: 300, cache_max_total_size: 1_048_576, logger: nil)
         @session = session
         @allowed_client_ids = allowed_client_ids
         @require_pkce = require_pkce
+        @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
         @max_response_size = max_response_size
         @cache_min_ttl = cache_min_ttl
         @cache_max_ttl = cache_max_ttl
@@ -147,6 +149,7 @@ module Himari
           redirect_uris: redirect_uris,
           confidential: false,
           require_pkce: @require_pkce,
+          ignore_localhost_redirect_uri_port: @ignore_localhost_redirect_uri_port,
         )
       end
 

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -92,7 +92,11 @@ module Himari
       end
 
       private def fetch_and_build(url)
-        resp = @session.get(url)
+        # stream: true must be passed to the request (not preset on the session via .with, which
+        # would yield an already-buffered Response with no #each). It returns a StreamResponse:
+        # status and headers are inspected first, then the body is consumed under a hard byte cap
+        # below, without buffering the whole body up front.
+        resp = @session.get(url, stream: true)
         # Surfaces transport/SSRF failures (HTTPX::Error) and HTTP >= 400. The draft also forbids
         # following redirects, so anything other than 200 (including 3xx) is an error too.
         resp.raise_for_status
@@ -100,16 +104,32 @@ module Himari
 
         content_length = resp.headers['content-length']
         raise FetchError, 'response exceeds maximum size' if content_length && content_length.to_i > @max_response_size
-
-        body = resp.body.to_s
-        raise FetchError, 'response exceeds maximum size' if body.bytesize > @max_response_size
         raise FetchError, 'unexpected content-type' unless json_content_type?(resp.headers['content-type'])
+
+        body = read_capped_body(resp)
 
         doc = JSON.parse(body, symbolize_names: true)
         registration = build_registration(doc, url)
         # The whole document is safe to log: it is size-capped and client_secret* is rejected.
         @logger&.info(Himari::LogLine.new('OauthClientMetadata: fetched', client_id: url, metadata: doc))
         [registration, compute_ttl(resp), body.bytesize]
+      end
+
+      # Stream the body and abort as soon as it exceeds the cap. The client_id URL is
+      # attacker-influenced and HTTPX has no hard body limit, so a malicious host could omit
+      # Content-Length and stream an unbounded response; capping during the read (rather than
+      # after buffering the whole body) prevents that memory/disk exhaustion.
+      #
+      # FIXME: this streaming read is a workaround for the lack of a built-in maximum body size in
+      # HTTPX. Replace it with a native body cap once available:
+      # https://gitlab.com/os85/httpx/-/work_items/383
+      private def read_capped_body(resp)
+        body = +''
+        resp.each do |chunk|
+          body << chunk
+          raise FetchError, 'response exceeds maximum size' if body.bytesize > @max_response_size
+        end
+        body
       end
 
       private def build_registration(doc, url)

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -102,7 +102,10 @@ module Himari
         raise FetchError, 'unexpected content-type' unless json_content_type?(resp.headers['content-type'])
 
         doc = JSON.parse(body, symbolize_names: true)
-        [build_registration(doc, url), compute_ttl(resp)]
+        registration = build_registration(doc, url)
+        # The whole document is safe to log: it is size-capped and client_secret* is rejected.
+        @logger&.info(Himari::LogLine.new('OauthClientMetadata: fetched', client_id: url, metadata: doc))
+        [registration, compute_ttl(resp)]
       end
 
       private def build_registration(doc, url)

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'time'
+require 'addressable/uri'
+require 'httpx'
+
+require 'himari/log_line'
+require 'himari/item_provider'
+require 'himari/client_registration'
+require 'himari/dynamic_client_registration'
+
+module Himari
+  module ItemProviders
+    # Resolves clients whose client_id is an https URL pointing to a JSON client metadata
+    # document, per draft-ietf-oauth-client-id-metadata-document. When the OIDC endpoints look
+    # a client up by id, this provider fetches and validates that document on demand and
+    # presents it as a public ClientRegistration.
+    #
+    # The HTTPX session is built once and retained for connection reuse; successful documents
+    # are cached in-memory (respecting HTTP cache headers within configured bounds). Errors and
+    # malformed documents are never cached, and the provider always fails closed (returns []),
+    # so a fetch problem surfaces as an unknown client rather than an exception.
+    class OauthClientMetadata
+      include Himari::ItemProvider
+
+      class FetchError < StandardError; end
+      class InvalidDocument < StandardError; end
+
+      CacheEntry = Struct.new(:value, :expires_at)
+
+      # @param session [HTTPX::Session] persistent, SSRF-filtered session (built by the middleware)
+      # @param allowed_client_ids [Array<String, Regexp>] empty = allow any compliant https URL
+      def initialize(session:, allowed_client_ids: [], require_pkce: true, max_response_size: 5120,
+        cache_min_ttl: 60, cache_max_ttl: 86400, cache_default_ttl: 300, logger: nil)
+        @session = session
+        @allowed_client_ids = allowed_client_ids
+        @require_pkce = require_pkce
+        @max_response_size = max_response_size
+        @cache_min_ttl = cache_min_ttl
+        @cache_max_ttl = cache_max_ttl
+        @cache_default_ttl = cache_default_ttl
+        @logger = logger
+        @cache = {}
+        @mutex = Mutex.new
+      end
+
+      def collect(id: nil, **_hint)
+        return [] unless id.is_a?(String)
+        return [] unless compliant_client_id_url?(id)
+        return [] unless allowed?(id)
+
+        cached = cache_get(id)
+        return [cached] if cached
+
+        registration, ttl = fetch_and_build(id)
+        cache_put(id, registration, ttl) if ttl.positive?
+        [registration]
+      rescue HTTPX::Error, FetchError, InvalidDocument, JSON::ParserError, Himari::DynamicClientRegistration::ValidationError => e
+        @logger&.warn(Himari::LogLine.new('OauthClientMetadata: client_id rejected', client_id: id, error: e.message))
+        []
+      end
+
+      private def compliant_client_id_url?(id)
+        uri = begin
+          Addressable::URI.parse(id)
+        rescue Addressable::URI::InvalidURIError
+          nil
+        end
+        return false unless uri
+        return false unless uri.scheme == 'https'
+        return false if uri.fragment
+        return false if uri.user || uri.password
+
+        path = uri.path
+        return false if path.nil? || path.empty?
+        return false if path.split('/').any? { |seg| seg == '.' || seg == '..' }
+
+        true
+      end
+
+      private def allowed?(id)
+        return true if @allowed_client_ids.empty?
+
+        @allowed_client_ids.any? do |matcher|
+          matcher.is_a?(Regexp) ? matcher.match?(id) : matcher.to_s == id
+        end
+      end
+
+      private def fetch_and_build(url)
+        resp = @session.get(url)
+        # Surfaces transport/SSRF failures (HTTPX::Error) and HTTP >= 400. The draft also forbids
+        # following redirects, so anything other than 200 (including 3xx) is an error too.
+        resp.raise_for_status
+        raise FetchError, "unexpected status: #{resp.status}" unless resp.status == 200
+
+        content_length = resp.headers['content-length']
+        raise FetchError, 'response exceeds maximum size' if content_length && content_length.to_i > @max_response_size
+
+        body = resp.body.to_s
+        raise FetchError, 'response exceeds maximum size' if body.bytesize > @max_response_size
+        raise FetchError, 'unexpected content-type' unless json_content_type?(resp.headers['content-type'])
+
+        doc = JSON.parse(body, symbolize_names: true)
+        [build_registration(doc, url), compute_ttl(resp)]
+      end
+
+      private def build_registration(doc, url)
+        raise InvalidDocument, 'document must be a JSON object' unless doc.is_a?(Hash)
+        raise InvalidDocument, 'client_id does not match document URL' unless doc[:client_id] == url
+        raise InvalidDocument, 'client_secret must not be present' if doc.key?(:client_secret) || doc.key?(:client_secret_expires_at)
+
+        auth_method = doc[:token_endpoint_auth_method]
+        raise InvalidDocument, "token_endpoint_auth_method must be 'none'" if auth_method && auth_method.to_s != 'none'
+
+        redirect_uris = Himari::DynamicClientRegistration.validate_redirect_uris(doc[:redirect_uris])
+
+        Himari::ClientRegistration.new(
+          id: url,
+          redirect_uris: redirect_uris,
+          confidential: false,
+          require_pkce: @require_pkce,
+        )
+      end
+
+      private def json_content_type?(value)
+        type = value.to_s.split(';', 2).first.to_s.strip.downcase
+        type == 'application/json' || type.end_with?('+json')
+      end
+
+      # Honour Cache-Control/Expires within configured bounds. no-store/no-cache disables caching.
+      private def compute_ttl(resp)
+        cache_control = resp.headers['cache-control'].to_s.downcase
+        return 0 if cache_control.include?('no-store') || cache_control.include?('no-cache')
+
+        ttl = if (m = cache_control.match(/max-age\s*=\s*(\d+)/))
+          m[1].to_i
+        elsif (expires = resp.headers['expires'])
+          parsed = begin
+            Time.httpdate(expires)
+          rescue ArgumentError
+            nil
+          end
+          parsed && (parsed - Time.now).to_i
+        end
+
+        (ttl || @cache_default_ttl).clamp(@cache_min_ttl, @cache_max_ttl)
+      end
+
+      private def cache_get(id)
+        @mutex.synchronize do
+          entry = @cache[id]
+          next nil unless entry
+
+          if entry.expires_at > Time.now.to_f
+            entry.value
+          else
+            @cache.delete(id)
+            nil
+          end
+        end
+      end
+
+      private def cache_put(id, value, ttl)
+        @mutex.synchronize do
+          @cache[id] = CacheEntry.new(value, Time.now.to_f + ttl)
+        end
+      end
+    end
+  end
+end

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -3,6 +3,8 @@
 require 'json'
 require 'time'
 require 'addressable/uri'
+require 'concurrent/map'
+require 'concurrent/atomic/atomic_fixnum'
 require 'httpx'
 
 require 'himari/log_line'
@@ -27,12 +29,12 @@ module Himari
       class FetchError < StandardError; end
       class InvalidDocument < StandardError; end
 
-      CacheEntry = Struct.new(:value, :expires_at)
+      CacheEntry = Struct.new(:value, :expires_at, :size, :seq)
 
       # @param session [HTTPX::Session] persistent, SSRF-filtered session (built by the middleware)
       # @param allowed_client_ids [Array<String, Regexp>] empty = allow any compliant https URL
       def initialize(session:, allowed_client_ids: [], require_pkce: true, max_response_size: 5120,
-        cache_min_ttl: 60, cache_max_ttl: 86400, cache_default_ttl: 300, logger: nil)
+        cache_min_ttl: 60, cache_max_ttl: 86400, cache_default_ttl: 300, cache_max_total_size: 1_048_576, logger: nil)
         @session = session
         @allowed_client_ids = allowed_client_ids
         @require_pkce = require_pkce
@@ -40,9 +42,11 @@ module Himari
         @cache_min_ttl = cache_min_ttl
         @cache_max_ttl = cache_max_ttl
         @cache_default_ttl = cache_default_ttl
+        @cache_max_total_size = cache_max_total_size
         @logger = logger
-        @cache = {}
-        @mutex = Mutex.new
+        @cache = Concurrent::Map.new
+        @cache_total_size = Concurrent::AtomicFixnum.new(0)
+        @cache_seq = Concurrent::AtomicFixnum.new(0)
       end
 
       def collect(id: nil, **_hint)
@@ -53,8 +57,8 @@ module Himari
         cached = cache_get(id)
         return [cached] if cached
 
-        registration, ttl = fetch_and_build(id)
-        cache_put(id, registration, ttl) if ttl.positive?
+        registration, ttl, size = fetch_and_build(id)
+        cache_put(id, registration, ttl, size) if ttl.positive?
         [registration]
       rescue HTTPX::Error, FetchError, InvalidDocument, JSON::ParserError, Himari::DynamicClientRegistration::ValidationError => e
         @logger&.warn(Himari::LogLine.new('OauthClientMetadata: client_id rejected', client_id: id, error: e.message))
@@ -105,7 +109,7 @@ module Himari
         registration = build_registration(doc, url)
         # The whole document is safe to log: it is size-capped and client_secret* is rejected.
         @logger&.info(Himari::LogLine.new('OauthClientMetadata: fetched', client_id: url, metadata: doc))
-        [registration, compute_ttl(resp)]
+        [registration, compute_ttl(resp), body.bytesize]
       end
 
       private def build_registration(doc, url)
@@ -151,23 +155,39 @@ module Himari
       end
 
       private def cache_get(id)
-        @mutex.synchronize do
-          entry = @cache[id]
-          next nil unless entry
+        entry = @cache[id]
+        return unless entry
+        return entry.value if entry.expires_at > Time.now.to_f
 
-          if entry.expires_at > Time.now.to_f
-            entry.value
-          else
-            @cache.delete(id)
-            nil
-          end
+        forget(id, entry)
+        nil
+      end
+
+      private def cache_put(id, value, ttl, size)
+        entry = CacheEntry.new(value, Time.now.to_f + ttl, size, @cache_seq.increment)
+        previous = @cache[id]
+        @cache[id] = entry
+        delta = size - (previous&.size || 0)
+        @cache_total_size.update { |total| total + delta }
+        evict_until_within_limit
+      end
+
+      # Drop the oldest (lowest seq) entries until the tracked total body size fits the limit.
+      # Sizes are approximate (original JSON body bytes); concurrent eviction may overshoot a
+      # little, which is acceptable for a cache.
+      private def evict_until_within_limit
+        while @cache_total_size.value > @cache_max_total_size
+          oldest = @cache.each_pair.min_by { |_id, entry| entry.seq }
+          break unless oldest
+
+          forget(*oldest)
         end
       end
 
-      private def cache_put(id, value, ttl)
-        @mutex.synchronize do
-          @cache[id] = CacheEntry.new(value, Time.now.to_f + ttl)
-        end
+      private def forget(id, entry)
+        return unless @cache.delete_pair(id, entry)
+
+        @cache_total_size.update { |total| total - entry.size }
       end
     end
   end

--- a/himari/lib/himari/item_providers/storage.rb
+++ b/himari/lib/himari/item_providers/storage.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'himari/item_provider'
+
+module Himari
+  module ItemProviders
+    # Looks up dynamically registered clients from storage and presents them to the OIDC
+    # endpoints as plain ClientRegistration objects. Lookups always carry an id hint; without
+    # one this returns nothing (there is no list operation). Expired registrations are filtered
+    # out here so backends without TTL (Memory, Filesystem) and DynamoDB's delayed TTL both
+    # fail closed.
+    class Storage
+      include Himari::ItemProvider
+
+      # @param storage [Himari::Storages::Base]
+      def initialize(storage:)
+        @storage = storage
+      end
+
+      def collect(id: nil, **_hint)
+        return [] unless id
+
+        client = @storage.find_dynamic_client(id)
+        client&.active? ? [client.to_client_registration] : []
+      end
+    end
+  end
+end

--- a/himari/lib/himari/middlewares/dynamic_clients.rb
+++ b/himari/lib/himari/middlewares/dynamic_clients.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'himari/dynamic_client_registration'
+require 'himari/item_providers/storage'
+require 'himari/middlewares/client'
+require 'himari/middlewares/config'
+
+module Himari
+  module Middlewares
+    # Enables RFC 7591 Dynamic Client Registration. Its presence in the Rack env
+    # (RACK_KEY) is what turns on the registration endpoint and its advertisement in the
+    # OIDC discovery document. It also appends a storage-backed provider to the client
+    # chain (Middlewares::Client::RACK_KEY) so registered clients resolve through the same
+    # client_provider.find(id:) lookup the OIDC endpoints already use.
+    #
+    # Must be placed after Middlewares::Config (it reads storage from the config).
+    class DynamicClients
+      RACK_KEY = 'himari.dynamic_clients'
+
+      Options = Data.define(:registration_lifetime, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
+
+      # @param registration_lifetime [Integer] seconds a registration stays valid (default 180 days)
+      def initialize(app, kwargs = {})
+        @app = app
+        @options = Options.new(
+          registration_lifetime: kwargs.fetch(:registration_lifetime) { Himari::DynamicClientRegistration::REGISTRATION_LIFETIME },
+          grant_types_supported: Himari::DynamicClientRegistration::SUPPORTED_GRANT_TYPES,
+          response_types_supported: Himari::DynamicClientRegistration::SUPPORTED_RESPONSE_TYPES,
+          token_endpoint_auth_methods_supported: Himari::DynamicClientRegistration::SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,
+        )
+      end
+
+      attr_reader :app
+
+      def call(env)
+        config = env[Himari::Middlewares::Config::RACK_KEY]
+        raise "Himari::Middlewares::DynamicClients must be placed after Himari::Middlewares::Config" unless config
+
+        env[RACK_KEY] = @options
+        env[Himari::Middlewares::Client::RACK_KEY] ||= []
+        env[Himari::Middlewares::Client::RACK_KEY] += [Himari::ItemProviders::Storage.new(storage: config.storage)]
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/himari/lib/himari/middlewares/dynamic_clients.rb
+++ b/himari/lib/himari/middlewares/dynamic_clients.rb
@@ -17,13 +17,16 @@ module Himari
     class DynamicClients
       RACK_KEY = 'himari.dynamic_clients'
 
-      Options = Data.define(:registration_lifetime, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
+      Options = Data.define(:registration_lifetime, :ignore_localhost_redirect_uri_port, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
 
       # @param registration_lifetime [Integer] seconds a registration stays valid (default 180 days)
+      # @param ignore_localhost_redirect_uri_port [Boolean] relax the port of loopback redirect_uris
+      #   for registered clients (default true; see RFC 8252 §7.3)
       def initialize(app, kwargs = {})
         @app = app
         @options = Options.new(
           registration_lifetime: kwargs.fetch(:registration_lifetime) { Himari::DynamicClientRegistration::REGISTRATION_LIFETIME },
+          ignore_localhost_redirect_uri_port: kwargs.fetch(:ignore_localhost_redirect_uri_port, true),
           grant_types_supported: Himari::DynamicClientRegistration::SUPPORTED_GRANT_TYPES,
           response_types_supported: Himari::DynamicClientRegistration::SUPPORTED_RESPONSE_TYPES,
           token_endpoint_auth_methods_supported: Himari::DynamicClientRegistration::SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,

--- a/himari/lib/himari/middlewares/metadata_clients.rb
+++ b/himari/lib/himari/middlewares/metadata_clients.rb
@@ -35,7 +35,9 @@ module Himari
       RACK_KEY = 'himari.metadata_clients'
 
       DEFAULT_USER_AGENT = "Himari-OauthClientMetadataFetch/#{Himari::VERSION} (+https://github.com/sorah/himari)"
-      DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10}.freeze
+      # read_timeout is set explicitly: the stream plugin otherwise defaults it to Infinity, which
+      # would let a slow sender hold the fetch open indefinitely.
+      DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10, read_timeout: 10}.freeze
 
       Options = Data.define(:allowed_client_ids, :require_pkce, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
 
@@ -79,10 +81,14 @@ module Himari
         @app.call(env)
       end
 
-      # Build a persistent, SSRF-filtered HTTPX session. Notably it does not enable the
-      # follow_redirects plugin: the draft requires redirects not be followed.
+      # Build a persistent, SSRF-filtered HTTPX session with the stream plugin loaded, so the
+      # provider can request a streaming response (get(url, stream: true)) and cap the body during
+      # the read instead of buffering it whole. stream: true is passed per-request, not set here
+      # via .with: a session-level stream option yields an already-buffered Response with no #each.
+      # Notably it does not enable the follow_redirects plugin: the draft requires redirects not be
+      # followed.
       private def build_session(options)
-        session = HTTPX.plugin(:persistent)
+        session = HTTPX.plugin(:persistent).plugin(:stream)
         session = case options.ssrf
         when true
           session.plugin(:ssrf_filter, allowed_schemes: %w(https))

--- a/himari/lib/himari/middlewares/metadata_clients.rb
+++ b/himari/lib/himari/middlewares/metadata_clients.rb
@@ -29,13 +29,15 @@ module Himari
     # - http_timeout [Hash] HTTPX timeout options.
     # - max_response_size [Integer] reject documents larger than this many bytes (default 5 KiB).
     # - cache_min_ttl / cache_max_ttl / cache_default_ttl [Integer] cache bounds in seconds.
+    # - cache_max_total_size [Integer] approximate cap on total cached document bytes; the oldest
+    #   entries are evicted once exceeded (default 1 MiB).
     class MetadataClients
       RACK_KEY = 'himari.metadata_clients'
 
       DEFAULT_USER_AGENT = "Himari-OauthClientMetadataFetch/#{Himari::VERSION} (+https://github.com/sorah/himari)"
       DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10}.freeze
 
-      Options = Data.define(:allowed_client_ids, :require_pkce, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl)
+      Options = Data.define(:allowed_client_ids, :require_pkce, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
 
       def initialize(app, kwargs = {})
         @app = app
@@ -49,6 +51,7 @@ module Himari
           cache_min_ttl: kwargs.fetch(:cache_min_ttl, 60),
           cache_max_ttl: kwargs.fetch(:cache_max_ttl, 86400),
           cache_default_ttl: kwargs.fetch(:cache_default_ttl, 300),
+          cache_max_total_size: kwargs.fetch(:cache_max_total_size, 1_048_576),
         )
         @provider = Himari::ItemProviders::OauthClientMetadata.new(
           session: build_session(@options),
@@ -58,6 +61,7 @@ module Himari
           cache_min_ttl: @options.cache_min_ttl,
           cache_max_ttl: @options.cache_max_ttl,
           cache_default_ttl: @options.cache_default_ttl,
+          cache_max_total_size: @options.cache_max_total_size,
           logger: kwargs[:logger],
         )
       end

--- a/himari/lib/himari/middlewares/metadata_clients.rb
+++ b/himari/lib/himari/middlewares/metadata_clients.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'httpx'
+
+require 'himari/version'
+require 'himari/item_providers/oauth_client_metadata'
+require 'himari/middlewares/client'
+require 'himari/middlewares/config'
+
+module Himari
+  module Middlewares
+    # Enables OAuth Client ID Metadata Document support
+    # (draft-ietf-oauth-client-id-metadata-document). Its presence in the Rack env (RACK_KEY)
+    # advertises support in the discovery documents. It appends a single, long-lived
+    # OauthClientMetadata provider to the client chain (Middlewares::Client::RACK_KEY) so URL
+    # client_ids resolve through the same client_provider.find(id:) lookup the OIDC endpoints
+    # already use; the provider retains its HTTPX session and document cache across requests.
+    #
+    # Must be placed after Middlewares::Config.
+    #
+    # Options:
+    # - allowed_client_ids [Array<String, Regexp>] empty (default) accepts any compliant https
+    #   URL; otherwise a client_id must match an entry (String exact, Regexp =~).
+    # - require_pkce [Boolean] force PKCE for metadata clients (default true; they are public).
+    # - ssrf [true, false, Hash] SSRF filtering. true (default) restricts to https; a Hash is
+    #   merged into the ssrf_filter plugin options (e.g. allowed_schemes); false disables it
+    #   (only for an authorization server running on a loopback address).
+    # - user_agent [String] User-Agent header for fetches.
+    # - http_timeout [Hash] HTTPX timeout options.
+    # - max_response_size [Integer] reject documents larger than this many bytes (default 5 KiB).
+    # - cache_min_ttl / cache_max_ttl / cache_default_ttl [Integer] cache bounds in seconds.
+    class MetadataClients
+      RACK_KEY = 'himari.metadata_clients'
+
+      DEFAULT_USER_AGENT = "Himari-OauthClientMetadataFetch/#{Himari::VERSION} (+https://github.com/sorah/himari)"
+      DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10}.freeze
+
+      Options = Data.define(:allowed_client_ids, :require_pkce, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl)
+
+      def initialize(app, kwargs = {})
+        @app = app
+        @options = Options.new(
+          allowed_client_ids: kwargs.fetch(:allowed_client_ids, []),
+          require_pkce: kwargs.fetch(:require_pkce, true),
+          ssrf: kwargs.fetch(:ssrf, true),
+          user_agent: kwargs.fetch(:user_agent, DEFAULT_USER_AGENT),
+          http_timeout: kwargs.fetch(:http_timeout, DEFAULT_HTTP_TIMEOUT),
+          max_response_size: kwargs.fetch(:max_response_size, 5120),
+          cache_min_ttl: kwargs.fetch(:cache_min_ttl, 60),
+          cache_max_ttl: kwargs.fetch(:cache_max_ttl, 86400),
+          cache_default_ttl: kwargs.fetch(:cache_default_ttl, 300),
+        )
+        @provider = Himari::ItemProviders::OauthClientMetadata.new(
+          session: build_session(@options),
+          allowed_client_ids: @options.allowed_client_ids,
+          require_pkce: @options.require_pkce,
+          max_response_size: @options.max_response_size,
+          cache_min_ttl: @options.cache_min_ttl,
+          cache_max_ttl: @options.cache_max_ttl,
+          cache_default_ttl: @options.cache_default_ttl,
+          logger: kwargs[:logger],
+        )
+      end
+
+      attr_reader :app, :options
+
+      def call(env)
+        config = env[Himari::Middlewares::Config::RACK_KEY]
+        raise "Himari::Middlewares::MetadataClients must be placed after Himari::Middlewares::Config" unless config
+
+        env[RACK_KEY] = @options
+        env[Himari::Middlewares::Client::RACK_KEY] ||= []
+        env[Himari::Middlewares::Client::RACK_KEY] += [@provider]
+
+        @app.call(env)
+      end
+
+      # Build a persistent, SSRF-filtered HTTPX session. Notably it does not enable the
+      # follow_redirects plugin: the draft requires redirects not be followed.
+      private def build_session(options)
+        session = HTTPX.plugin(:persistent)
+        session = case options.ssrf
+        when true
+          session.plugin(:ssrf_filter, allowed_schemes: %w(https))
+        when Hash
+          ssrf_options = {allowed_schemes: %w(https)}.merge(options.ssrf)
+          session.plugin(:ssrf_filter, **ssrf_options)
+        when false
+          session
+        else
+          raise ArgumentError, "ssrf option must be true, false, or a Hash"
+        end
+        session.with(
+          headers: {'user-agent' => options.user_agent, 'accept' => 'application/json'},
+          timeout: options.http_timeout,
+        )
+      end
+    end
+  end
+end

--- a/himari/lib/himari/middlewares/metadata_clients.rb
+++ b/himari/lib/himari/middlewares/metadata_clients.rb
@@ -22,6 +22,8 @@ module Himari
     # - allowed_client_ids [Array<String, Regexp>] empty (default) accepts any compliant https
     #   URL; otherwise a client_id must match an entry (String exact, Regexp =~).
     # - require_pkce [Boolean] force PKCE for metadata clients (default true; they are public).
+    # - ignore_localhost_redirect_uri_port [Boolean] relax the port of loopback redirect_uris when
+    #   matching at the authorization endpoint (default true; see RFC 8252 §7.3).
     # - ssrf [true, false, Hash] SSRF filtering. true (default) restricts to https; a Hash is
     #   merged into the ssrf_filter plugin options (e.g. allowed_schemes); false disables it
     #   (only for an authorization server running on a loopback address).
@@ -39,13 +41,14 @@ module Himari
       # would let a slow sender hold the fetch open indefinitely.
       DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10, read_timeout: 10}.freeze
 
-      Options = Data.define(:allowed_client_ids, :require_pkce, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
+      Options = Data.define(:allowed_client_ids, :require_pkce, :ignore_localhost_redirect_uri_port, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
 
       def initialize(app, kwargs = {})
         @app = app
         @options = Options.new(
           allowed_client_ids: kwargs.fetch(:allowed_client_ids, []),
           require_pkce: kwargs.fetch(:require_pkce, true),
+          ignore_localhost_redirect_uri_port: kwargs.fetch(:ignore_localhost_redirect_uri_port, true),
           ssrf: kwargs.fetch(:ssrf, true),
           user_agent: kwargs.fetch(:user_agent, DEFAULT_USER_AGENT),
           http_timeout: kwargs.fetch(:http_timeout, DEFAULT_HTTP_TIMEOUT),
@@ -59,6 +62,7 @@ module Himari
           session: build_session(@options),
           allowed_client_ids: @options.allowed_client_ids,
           require_pkce: @options.require_pkce,
+          ignore_localhost_redirect_uri_port: @options.ignore_localhost_redirect_uri_port,
           max_response_size: @options.max_response_size,
           cache_min_ttl: @options.cache_min_ttl,
           cache_max_ttl: @options.cache_max_ttl,

--- a/himari/lib/himari/services/client_registration_endpoint.rb
+++ b/himari/lib/himari/services/client_registration_endpoint.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rack/request'
+require 'himari/log_line'
+require 'himari/dynamic_client_registration'
+
+module Himari
+  module Services
+    # RFC 7591 OAuth 2.0 Dynamic Client Registration endpoint. Accepts a JSON client metadata
+    # document via POST, persists a Himari::DynamicClientRegistration, and returns the client
+    # information response (including a one-time client_secret for confidential clients).
+    class ClientRegistrationEndpoint
+      # @param storage [Himari::Storages::Base]
+      # @param registration_lifetime [Integer] seconds a registration stays valid
+      # @param logger [Logger, nil]
+      def initialize(storage:, registration_lifetime: Himari::DynamicClientRegistration::REGISTRATION_LIFETIME, logger: nil)
+        @storage = storage
+        @registration_lifetime = registration_lifetime
+        @logger = logger
+      end
+
+      def app
+        self
+      end
+
+      def call(env)
+        request = Rack::Request.new(env)
+        return error_response(405, :invalid_request, 'method not allowed') unless request.post?
+
+        metadata = parse_body(request)
+        return error_response(400, :invalid_client_metadata, 'request body must be a JSON object') unless metadata
+
+        client = Himari::DynamicClientRegistration.register(
+          metadata: metadata,
+          lifetime: @registration_lifetime,
+          registration_ip: request.ip,
+          registration_remote_addr: env['REMOTE_ADDR'],
+          registration_x_forwarded_for: env['HTTP_X_FORWARDED_FOR'],
+        )
+        @storage.put_dynamic_client(client)
+
+        @logger&.info(Himari::LogLine.new('ClientRegistrationEndpoint: registered', req: env['himari.request_as_log'], client: client.as_log))
+
+        json_response(201, client.registration_response)
+      rescue Himari::DynamicClientRegistration::ValidationError => e
+        @logger&.warn(Himari::LogLine.new('ClientRegistrationEndpoint: rejected', req: env['himari.request_as_log'], err: e.error_code, message: e.message))
+        error_response(400, e.error_code, e.message)
+      end
+
+      private def parse_body(request)
+        return unless request.media_type == 'application/json'
+
+        body = request.body.read
+        parsed = JSON.parse(body, symbolize_names: true)
+        parsed.is_a?(Hash) ? parsed : nil
+      rescue JSON::ParserError
+        nil
+      end
+
+      private def json_response(status, body)
+        [
+          status,
+          {'Content-Type' => 'application/json', 'Cache-Control' => 'no-store', 'Pragma' => 'no-cache'},
+          [JSON.generate(body), "\n"],
+        ]
+      end
+
+      private def error_response(status, error, description)
+        json_response(status, {error: error, error_description: description})
+      end
+    end
+  end
+end

--- a/himari/lib/himari/services/client_registration_endpoint.rb
+++ b/himari/lib/himari/services/client_registration_endpoint.rb
@@ -13,10 +13,13 @@ module Himari
     class ClientRegistrationEndpoint
       # @param storage [Himari::Storages::Base]
       # @param registration_lifetime [Integer] seconds a registration stays valid
+      # @param ignore_localhost_redirect_uri_port [Boolean] relax loopback redirect_uri ports for
+      #   registered clients (default true; see RFC 8252 §7.3)
       # @param logger [Logger, nil]
-      def initialize(storage:, registration_lifetime: Himari::DynamicClientRegistration::REGISTRATION_LIFETIME, logger: nil)
+      def initialize(storage:, registration_lifetime: Himari::DynamicClientRegistration::REGISTRATION_LIFETIME, ignore_localhost_redirect_uri_port: true, logger: nil)
         @storage = storage
         @registration_lifetime = registration_lifetime
+        @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
         @logger = logger
       end
 
@@ -34,6 +37,7 @@ module Himari
         client = Himari::DynamicClientRegistration.register(
           metadata: metadata,
           lifetime: @registration_lifetime,
+          ignore_localhost_redirect_uri_port: @ignore_localhost_redirect_uri_port,
           registration_ip: request.ip,
           registration_remote_addr: env['REMOTE_ADDR'],
           registration_x_forwarded_for: env['HTTP_X_FORWARDED_FOR'],

--- a/himari/lib/himari/services/oidc_authorization_endpoint.rb
+++ b/himari/lib/himari/services/oidc_authorization_endpoint.rb
@@ -40,7 +40,19 @@ module Himari
           end
           raise "[BUG] client.id != authz.cilent_id" unless @authz.client_id == @client.id
 
-          res.redirect_uri = req.verify_redirect_uri!(@client.redirect_uris)
+          given_redirect_uri = req.redirect_uri&.to_s
+          res.redirect_uri = if given_redirect_uri && !given_redirect_uri.empty?
+            # Raise before recording the redirect_uri so we never redirect errors to an unverified URI.
+            next req.bad_request!(:invalid_request, '"redirect_uri" mismatch') unless @client.redirect_uri_covers?(given_redirect_uri)
+
+            given_redirect_uri
+          elsif @client.redirect_uris.size == 1
+            @client.redirect_uris.first
+          else
+            next req.bad_request!(:invalid_request, '"redirect_uri" missing')
+          end
+          # rack-oauth2 redirects subsequent errors back to the verified redirect_uri via this accessor.
+          req.verified_redirect_uri = res.redirect_uri
 
           req.unsupported_response_type! if res.protocol_params_location == :fragment
           req.bad_request!(:request_uri_not_supported, "Request Object is not implemented") if req.request_uri || req.request

--- a/himari/lib/himari/services/oidc_authorization_endpoint.rb
+++ b/himari/lib/himari/services/oidc_authorization_endpoint.rb
@@ -46,7 +46,7 @@ module Himari
             next req.bad_request!(:invalid_request, '"redirect_uri" mismatch') unless @client.redirect_uri_covers?(given_redirect_uri)
 
             given_redirect_uri
-          elsif @client.redirect_uris.size == 1
+          elsif @client.redirect_uris.size == 1 && @client.redirect_uris.first.is_a?(String)
             @client.redirect_uris.first
           else
             next req.bad_request!(:invalid_request, '"redirect_uri" missing')

--- a/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
+++ b/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
@@ -4,9 +4,11 @@ module Himari
   module Services
     class OidcProviderMetadataEndpoint
       # @param signing_key_provider [Himari::ProviderChain<Himari::SigningKey>]
-      def initialize(signing_key_provider:, issuer:)
+      # @param registration_endpoint [String, nil] advertised when Dynamic Client Registration is enabled
+      def initialize(signing_key_provider:, issuer:, registration_endpoint: nil)
         @signing_key_provider = signing_key_provider
         @issuer = issuer
+        @registration_endpoint = registration_endpoint
       end
 
       def app
@@ -14,15 +16,16 @@ module Himari
       end
 
       def call(env)
-        Handler.new(signing_key_provider: @signing_key_provider, issuer: @issuer, env: env).response
+        Handler.new(signing_key_provider: @signing_key_provider, issuer: @issuer, registration_endpoint: @registration_endpoint, env: env).response
       end
 
       class Handler
         class InvalidToken < StandardError; end
 
-        def initialize(signing_key_provider:, issuer:, env:)
+        def initialize(signing_key_provider:, issuer:, env:, registration_endpoint: nil)
           @signing_key_provider = signing_key_provider
           @issuer = issuer
+          @registration_endpoint = registration_endpoint
           @env = env
         end
 
@@ -34,12 +37,16 @@ module Himari
             token_endpoint: "#{@issuer}/public/oidc/token",
             userinfo_endpoint: "#{@issuer}/public/oidc/userinfo",
             jwks_uri: "#{@issuer}/public/jwks",
+            registration_endpoint: @registration_endpoint,
             scopes_supported: %w(openid),
             response_types_supported: ['code'], # violation: dynamic OpenID Provider MUST support code, id_token, token+id_token
+            grant_types_supported: %w(authorization_code refresh_token),
+            token_endpoint_auth_methods_supported: %w(client_secret_basic client_secret_post none),
+            code_challenge_methods_supported: %w(S256 plain),
             subject_types_supported: ['public'],
             id_token_signing_alg_values_supported: signing_keys.map(&:alg).uniq.sort,
             claims_supported: %w(sub iss iat nbf exp),
-          }
+          }.compact
         end
 
         def response

--- a/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
+++ b/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
@@ -5,10 +5,12 @@ module Himari
     class OidcProviderMetadataEndpoint
       # @param signing_key_provider [Himari::ProviderChain<Himari::SigningKey>]
       # @param registration_endpoint [String, nil] advertised when Dynamic Client Registration is enabled
-      def initialize(signing_key_provider:, issuer:, registration_endpoint: nil)
+      # @param client_id_metadata_document_supported [Boolean] advertised when OAuth Client ID Metadata Document support is enabled
+      def initialize(signing_key_provider:, issuer:, registration_endpoint: nil, client_id_metadata_document_supported: false)
         @signing_key_provider = signing_key_provider
         @issuer = issuer
         @registration_endpoint = registration_endpoint
+        @client_id_metadata_document_supported = client_id_metadata_document_supported
       end
 
       def app
@@ -16,16 +18,17 @@ module Himari
       end
 
       def call(env)
-        Handler.new(signing_key_provider: @signing_key_provider, issuer: @issuer, registration_endpoint: @registration_endpoint, env: env).response
+        Handler.new(signing_key_provider: @signing_key_provider, issuer: @issuer, registration_endpoint: @registration_endpoint, client_id_metadata_document_supported: @client_id_metadata_document_supported, env: env).response
       end
 
       class Handler
         class InvalidToken < StandardError; end
 
-        def initialize(signing_key_provider:, issuer:, env:, registration_endpoint: nil)
+        def initialize(signing_key_provider:, issuer:, env:, registration_endpoint: nil, client_id_metadata_document_supported: false)
           @signing_key_provider = signing_key_provider
           @issuer = issuer
           @registration_endpoint = registration_endpoint
+          @client_id_metadata_document_supported = client_id_metadata_document_supported
           @env = env
         end
 
@@ -38,6 +41,7 @@ module Himari
             userinfo_endpoint: "#{@issuer}/public/oidc/userinfo",
             jwks_uri: "#{@issuer}/public/jwks",
             registration_endpoint: @registration_endpoint,
+            client_id_metadata_document_supported: @client_id_metadata_document_supported ? true : nil,
             scopes_supported: %w(openid),
             response_types_supported: ['code'], # violation: dynamic OpenID Provider MUST support code, id_token, token+id_token
             grant_types_supported: %w(authorization_code refresh_token),

--- a/himari/lib/himari/services/oidc_token_endpoint.rb
+++ b/himari/lib/himari/services/oidc_token_endpoint.rb
@@ -44,7 +44,9 @@ module Himari
             @logger&.warn(Himari::LogLine.new('OidcTokenEndpoint: invalid_client, no client registration', req: env['himari.request_as_log'], client_id: req.client_id))
             next req.invalid_client!
           end
-          unless client.match_secret?(req.client_secret)
+          # Public clients (token_endpoint_auth_method=none) present no secret; they are bound
+          # to the authorization code by PKCE and the client_id check in handle_authorization_code.
+          if client.confidential? && !client.match_secret?(req.client_secret)
             @logger&.warn(Himari::LogLine.new('OidcTokenEndpoint: invalid_client, client secret mismatch', req: env['himari.request_as_log'], client: client.as_log))
             next req.invalid_client!
           end
@@ -64,6 +66,10 @@ module Himari
         authz = @storage.find_authorization(req.code)
         unless authz
           @logger&.warn(Himari::LogLine.new('OidcTokenEndpoint: invalid_grant, no grant code found', req: env['himari.request_as_log'], client: client.as_log))
+          return req.invalid_grant!
+        end
+        unless authz.client_id == client.id
+          @logger&.warn(Himari::LogLine.new('OidcTokenEndpoint: invalid_grant, grant client_id mismatch', req: env['himari.request_as_log'], client: client.as_log, grant: authz.as_log))
           return req.invalid_grant!
         end
         unless authz.valid_redirect_uri?(req.redirect_uri)

--- a/himari/lib/himari/storages/base.rb
+++ b/himari/lib/himari/storages/base.rb
@@ -4,6 +4,7 @@ require 'himari/authorization_code'
 require 'himari/access_token'
 require 'himari/refresh_token'
 require 'himari/session_data'
+require 'himari/dynamic_client_registration'
 
 module Himari
   module Storages
@@ -62,6 +63,27 @@ module Himari
 
       def delete_refresh_token_by_handle(handle)
         delete('refresh', handle)
+      end
+
+      def find_dynamic_client(id)
+        # ids are server-generated url-safe base64; reject anything else before it reaches a
+        # storage key (defense-in-depth against path traversal on filesystem-backed storage).
+        return unless id.is_a?(String) && id.match?(/\A[A-Za-z0-9_-]+\z/)
+
+        content = read('dynamic_client', id)
+        content && DynamicClientRegistration.from_json(content)
+      end
+
+      def put_dynamic_client(client, overwrite: false)
+        write('dynamic_client', client.id, client.as_json, overwrite: overwrite)
+      end
+
+      def delete_dynamic_client(client)
+        delete_dynamic_client_by_id(client.id)
+      end
+
+      def delete_dynamic_client_by_id(id)
+        delete('dynamic_client', id)
       end
 
       def find_session(handle)

--- a/himari/spec/himari/app_dynamic_clients_spec.rb
+++ b/himari/spec/himari/app_dynamic_clients_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/builder'
+require 'himari'
+require 'himari/middlewares/config'
+require 'himari/middlewares/dynamic_clients'
+require 'himari/storages/memory'
+
+RSpec.describe 'App dynamic client registration routes' do
+  include Rack::Test::Methods
+
+  let(:storage) { Himari::Storages::Memory.new }
+  let(:dynamic_clients_enabled) { true }
+
+  let(:app) do
+    s = storage
+    enabled = dynamic_clients_enabled
+    Rack::Builder.new do
+      use Himari::Middlewares::Config, issuer: 'https://test.invalid', storage: s, log_level: Logger::FATAL
+      use Himari::Middlewares::DynamicClients if enabled
+      run Himari::App
+    end
+  end
+
+  context "when DynamicClients middleware is enabled" do
+    it "registers a client and advertises the endpoint" do
+      post '/public/oidc/register', JSON.generate(redirect_uris: %w(https://rp.test.invalid/cb), token_endpoint_auth_method: 'none'), {'CONTENT_TYPE' => 'application/json'}
+      expect(last_response.status).to eq(201)
+
+      get '/.well-known/openid-configuration'
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body[:registration_endpoint]).to eq('https://test.invalid/public/oidc/register')
+    end
+
+    it "answers 405 for a non-POST request to the registration endpoint" do
+      get '/public/oidc/register'
+      expect(last_response.status).to eq(405)
+      expect(JSON.parse(last_response.body, symbolize_names: true)[:error]).to eq('invalid_request')
+    end
+  end
+
+  context "when DynamicClients middleware is absent" do
+    let(:dynamic_clients_enabled) { false }
+
+    it "returns 404 for the registration endpoint and omits the advertisement" do
+      post '/public/oidc/register', JSON.generate(redirect_uris: %w(https://rp.test.invalid/cb)), {'CONTENT_TYPE' => 'application/json'}
+      expect(last_response.status).to eq(404)
+
+      get '/.well-known/openid-configuration'
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body).not_to have_key(:registration_endpoint)
+    end
+  end
+end

--- a/himari/spec/himari/app_metadata_spec.rb
+++ b/himari/spec/himari/app_metadata_spec.rb
@@ -4,17 +4,21 @@ require 'spec_helper'
 require 'rack/builder'
 require 'himari'
 require 'himari/middlewares/config'
+require 'himari/middlewares/metadata_clients'
 require 'himari/storages/memory'
 
 RSpec.describe 'App authorization server metadata routes' do
   include Rack::Test::Methods
 
   let(:storage) { Himari::Storages::Memory.new }
+  let(:metadata_clients_enabled) { false }
 
   let(:app) do
     s = storage
+    enabled = metadata_clients_enabled
     Rack::Builder.new do
       use Himari::Middlewares::Config, issuer: 'https://test.invalid', storage: s, log_level: Logger::FATAL
+      use Himari::Middlewares::MetadataClients if enabled
       run Himari::App
     end
   end
@@ -37,6 +41,30 @@ RSpec.describe 'App authorization server metadata routes' do
 
       get '/.well-known/openid-configuration'
       expect(oauth_body).to eq(last_response.body)
+    end
+  end
+
+  describe 'client_id_metadata_document_supported advertisement' do
+    context 'when MetadataClients is absent' do
+      it 'omits the flag from both documents' do
+        %w(/.well-known/openid-configuration /.well-known/oauth-authorization-server).each do |path|
+          get path
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body).not_to have_key(:client_id_metadata_document_supported)
+        end
+      end
+    end
+
+    context 'when MetadataClients is enabled' do
+      let(:metadata_clients_enabled) { true }
+
+      it 'advertises the flag in both documents' do
+        %w(/.well-known/openid-configuration /.well-known/oauth-authorization-server).each do |path|
+          get path
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body[:client_id_metadata_document_supported]).to eq(true)
+        end
+      end
     end
   end
 end

--- a/himari/spec/himari/app_metadata_spec.rb
+++ b/himari/spec/himari/app_metadata_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/builder'
+require 'himari'
+require 'himari/middlewares/config'
+require 'himari/storages/memory'
+
+RSpec.describe 'App authorization server metadata routes' do
+  include Rack::Test::Methods
+
+  let(:storage) { Himari::Storages::Memory.new }
+
+  let(:app) do
+    s = storage
+    Rack::Builder.new do
+      use Himari::Middlewares::Config, issuer: 'https://test.invalid', storage: s, log_level: Logger::FATAL
+      run Himari::App
+    end
+  end
+
+  describe 'GET /.well-known/openid-configuration (OpenID Connect Discovery)' do
+    it 'returns metadata' do
+      get '/.well-known/openid-configuration'
+      expect(last_response).to be_ok
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body[:issuer]).to eq('https://test.invalid')
+    end
+  end
+
+  describe 'GET /.well-known/oauth-authorization-server (RFC 8414)' do
+    it 'returns metadata identical to OpenID Connect Discovery' do
+      get '/.well-known/oauth-authorization-server'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to eq('application/json; charset=utf-8')
+      oauth_body = last_response.body
+
+      get '/.well-known/openid-configuration'
+      expect(oauth_body).to eq(last_response.body)
+    end
+  end
+end

--- a/himari/spec/himari/client_registration_spec.rb
+++ b/himari/spec/himari/client_registration_spec.rb
@@ -22,6 +22,27 @@ RSpec.describe Himari::ClientRegistration do
         expect(client.match_secret?('incorrect')).to eq(false)
       end
     end
+
+    context "with a public client (confidential: false)" do
+      let(:client) { described_class.new(id: 'a', redirect_uris: [], confidential: false, require_pkce: true) }
+
+      it "needs no secret and never matches one" do
+        expect(client.confidential?).to eq(false)
+        expect(client.require_pkce).to eq(true)
+        expect(client.match_secret?('anything')).to eq(false)
+        expect(client.match_secret?(nil)).to eq(false)
+      end
+    end
+  end
+
+  describe "confidential validation" do
+    it "requires a secret for confidential clients" do
+      expect { described_class.new(id: 'a', redirect_uris: []) }.to raise_error(ArgumentError)
+    end
+
+    it "allows a public client without a secret" do
+      expect { described_class.new(id: 'a', redirect_uris: [], confidential: false) }.not_to raise_error
+    end
   end
 
   describe "#match_hint?" do

--- a/himari/spec/himari/client_registration_spec.rb
+++ b/himari/spec/himari/client_registration_spec.rb
@@ -113,6 +113,26 @@ RSpec.describe Himari::ClientRegistration do
       end
     end
 
+    context "with a Regexp registered redirect_uri" do
+      let(:redirect_uris) { [%r{\Ahttps://rp\.invalid/cb/[0-9]+\z}] }
+
+      it "matches via the pattern" do
+        expect(client.redirect_uri_covers?('https://rp.invalid/cb/123')).to eq(true)
+        expect(client.redirect_uri_covers?('https://rp.invalid/cb/abc')).to eq(false)
+        expect(client.redirect_uri_covers?('https://attacker.invalid/cb/123')).to eq(false)
+      end
+    end
+
+    context "with a mix of String and Regexp entries" do
+      let(:redirect_uris) { ['https://rp.invalid/cb', %r{\Ahttps://rp\.invalid/alt/}] }
+
+      it "matches against either" do
+        expect(client.redirect_uri_covers?('https://rp.invalid/cb')).to eq(true)
+        expect(client.redirect_uri_covers?('https://rp.invalid/alt/x')).to eq(true)
+        expect(client.redirect_uri_covers?('https://rp.invalid/other')).to eq(false)
+      end
+    end
+
     context "with ignore_localhost_redirect_uri_port disabled" do
       let(:client) { described_class.new(id: 'a', redirect_uris:, confidential: false, ignore_localhost_redirect_uri_port: false) }
       let(:redirect_uris) { ['http://127.0.0.1:3000/cb'] }

--- a/himari/spec/himari/client_registration_spec.rb
+++ b/himari/spec/himari/client_registration_spec.rb
@@ -54,4 +54,73 @@ RSpec.describe Himari::ClientRegistration do
       expect(client.match_hint?(id: 'b')).to eq(false)
     end
   end
+
+  describe "#redirect_uri_covers?" do
+    let(:client) { described_class.new(id: 'a', redirect_uris:, confidential: false) }
+
+    context "with a regular redirect_uri" do
+      let(:redirect_uris) { ['https://rp.invalid/cb'] }
+
+      it "matches only on exact string comparison" do
+        expect(client.redirect_uri_covers?('https://rp.invalid/cb')).to eq(true)
+        expect(client.redirect_uri_covers?('https://rp.invalid/cb?x=1')).to eq(false)
+        expect(client.redirect_uri_covers?('https://rp.invalid/other')).to eq(false)
+        expect(client.redirect_uri_covers?('https://attacker.invalid/cb')).to eq(false)
+        expect(client.redirect_uri_covers?(nil)).to eq(false)
+        expect(client.redirect_uri_covers?('')).to eq(false)
+      end
+    end
+
+    context "with ignore_localhost_redirect_uri_port enabled (default)" do
+      let(:redirect_uris) { ['http://127.0.0.1/cb'] }
+
+      it "defaults to true" do
+        expect(client.ignore_localhost_redirect_uri_port).to eq(true)
+      end
+
+      %w(127.0.0.1 [::1] localhost).each do |host|
+        context "with loopback host #{host} over http" do
+          let(:redirect_uris) { ["http://#{host}/cb"] }
+
+          it "ignores the port" do
+            expect(client.redirect_uri_covers?("http://#{host}/cb")).to eq(true)
+            expect(client.redirect_uri_covers?("http://#{host}:54321/cb")).to eq(true)
+            expect(client.redirect_uri_covers?("http://#{host}:0/cb")).to eq(true)
+          end
+
+          it "still requires scheme, host, path and query to match" do
+            expect(client.redirect_uri_covers?("https://#{host}:54321/cb")).to eq(false)
+            expect(client.redirect_uri_covers?("http://#{host}:54321/other")).to eq(false)
+            expect(client.redirect_uri_covers?("http://#{host}:54321/cb?x=1")).to eq(false)
+          end
+        end
+      end
+
+      context "with a loopback host over https" do
+        let(:redirect_uris) { ['https://localhost/cb'] }
+
+        it "also ignores the port" do
+          expect(client.redirect_uri_covers?('https://localhost:8443/cb')).to eq(true)
+        end
+      end
+
+      context "with a non-loopback host" do
+        let(:redirect_uris) { ['https://rp.invalid:443/cb'] }
+
+        it "does not ignore the port" do
+          expect(client.redirect_uri_covers?('https://rp.invalid:8443/cb')).to eq(false)
+        end
+      end
+    end
+
+    context "with ignore_localhost_redirect_uri_port disabled" do
+      let(:client) { described_class.new(id: 'a', redirect_uris:, confidential: false, ignore_localhost_redirect_uri_port: false) }
+      let(:redirect_uris) { ['http://127.0.0.1:3000/cb'] }
+
+      it "requires exact loopback port match" do
+        expect(client.redirect_uri_covers?('http://127.0.0.1:3000/cb')).to eq(true)
+        expect(client.redirect_uri_covers?('http://127.0.0.1:54321/cb')).to eq(false)
+      end
+    end
+  end
 end

--- a/himari/spec/himari/dynamic_client_registration_spec.rb
+++ b/himari/spec/himari/dynamic_client_registration_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'himari/dynamic_client_registration'
+
+RSpec.describe Himari::DynamicClientRegistration do
+  let(:redirect_uris) { %w(https://rp.test.invalid/callback) }
+
+  describe ".register" do
+    context "with token_endpoint_auth_method=none (public client)" do
+      subject(:client) do
+        described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'none'})
+      end
+
+      it "is a public client requiring PKCE without a secret" do
+        expect(client.confidential?).to eq(false)
+        expect(client.require_pkce).to eq(true)
+        expect(client.secret).to be_nil
+        expect(client.secret_hash).to be_nil
+      end
+
+      it "defaults grant_types and response_types" do
+        expect(client.grant_types).to eq(%w(authorization_code))
+        expect(client.response_types).to eq(%w(code))
+      end
+
+      it "omits client_secret from the registration response" do
+        expect(client.registration_response).not_to have_key(:client_secret)
+      end
+    end
+
+    context "with confidential auth method" do
+      subject(:client) do
+        described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'client_secret_basic'})
+      end
+
+      it "generates a secret verifiable via the converted ClientRegistration" do
+        expect(client.confidential?).to eq(true)
+        expect(client.require_pkce).to eq(false)
+        expect(client.secret).to be_a(String)
+        registration = client.to_client_registration
+        expect(registration.match_secret?(client.secret)).to eq(true)
+        expect(registration.match_secret?('wrong')).to eq(false)
+      end
+
+      it "returns the plaintext secret once in the registration response" do
+        response = client.registration_response
+        expect(response[:client_secret]).to eq(client.secret)
+        expect(response[:client_secret_expires_at]).to eq(client.expiry)
+      end
+
+      it "defaults token_endpoint_auth_method to client_secret_basic" do
+        c = described_class.register(metadata: {redirect_uris: redirect_uris})
+        expect(c.token_endpoint_auth_method).to eq('client_secret_basic')
+      end
+    end
+
+    context "with refresh_token grant" do
+      it "is accepted" do
+        client = described_class.register(metadata: {redirect_uris: redirect_uris, grant_types: %w(authorization_code refresh_token)})
+        expect(client.grant_types).to eq(%w(authorization_code refresh_token))
+      end
+    end
+
+    it "captures registration source" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris}, registration_ip: '203.0.113.1', registration_remote_addr: '198.51.100.1', registration_x_forwarded_for: '203.0.113.1, 198.51.100.1')
+      expect(client.registration_ip).to eq('203.0.113.1')
+      expect(client.registration_remote_addr).to eq('198.51.100.1')
+      expect(client.registration_x_forwarded_for).to eq('203.0.113.1, 198.51.100.1')
+    end
+
+    it "expires 180 days after issuance by default" do
+      now = Time.at(1_700_000_000)
+      client = described_class.register(metadata: {redirect_uris: redirect_uris}, now: now)
+      expect(client.client_id_issued_at).to eq(now.to_i)
+      expect(client.expiry).to eq(now.to_i + (180 * 86400))
+    end
+
+    it "honors a custom lifetime" do
+      now = Time.at(1_700_000_000)
+      client = described_class.register(metadata: {redirect_uris: redirect_uris}, lifetime: 3600, now: now)
+      expect(client.expiry).to eq(now.to_i + 3600)
+    end
+
+    describe "validation" do
+      it "rejects missing redirect_uris" do
+        expect { described_class.register(metadata: {}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects empty redirect_uris" do
+        expect { described_class.register(metadata: {redirect_uris: []}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects a redirect_uri without a scheme" do
+        expect { described_class.register(metadata: {redirect_uris: %w(/relative)}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects a redirect_uri with a fragment" do
+        expect { described_class.register(metadata: {redirect_uris: %w(https://rp.test.invalid/cb#frag)}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects a redirect_uri with a dangerous scheme" do
+        expect { described_class.register(metadata: {redirect_uris: ['javascript:alert(1)//']}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects too many redirect_uris" do
+        uris = Array.new(described_class::MAX_REDIRECT_URIS + 1) { |i| "https://rp.test.invalid/cb#{i}" }
+        expect { described_class.register(metadata: {redirect_uris: uris}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects an overlong redirect_uri" do
+        long = "https://rp.test.invalid/#{"a" * described_class::MAX_URI_LENGTH}"
+        expect { described_class.register(metadata: {redirect_uris: [long]}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_redirect_uri) }
+      end
+
+      it "rejects an overlong client_name" do
+        expect { described_class.register(metadata: {redirect_uris: redirect_uris, client_name: 'x' * (described_class::MAX_CLIENT_NAME_LENGTH + 1)}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_client_metadata) }
+      end
+
+      it "accepts a client_name at the limit" do
+        client = described_class.register(metadata: {redirect_uris: redirect_uris, client_name: 'x' * described_class::MAX_CLIENT_NAME_LENGTH})
+        expect(client.client_name.length).to eq(described_class::MAX_CLIENT_NAME_LENGTH)
+      end
+
+      it "accepts and echoes a valid client_uri" do
+        client = described_class.register(metadata: {redirect_uris: redirect_uris, client_uri: 'https://app.test.invalid/'})
+        expect(client.client_uri).to eq('https://app.test.invalid/')
+        expect(client.registration_response[:client_uri]).to eq('https://app.test.invalid/')
+      end
+
+      it "rejects an overlong client_uri" do
+        long = "https://app.test.invalid/#{"a" * described_class::MAX_URI_LENGTH}"
+        expect { described_class.register(metadata: {redirect_uris: redirect_uris, client_uri: long}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_client_metadata) }
+      end
+
+      it "rejects a client_uri that is not a valid URL" do
+        expect { described_class.register(metadata: {redirect_uris: redirect_uris, client_uri: 'not a url'}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_client_metadata) }
+      end
+
+      it "rejects an unsupported token_endpoint_auth_method" do
+        expect { described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'private_key_jwt'}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_client_metadata) }
+      end
+
+      it "rejects an unsupported grant_type" do
+        expect { described_class.register(metadata: {redirect_uris: redirect_uris, grant_types: %w(client_credentials)}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_client_metadata) }
+      end
+
+      it "rejects an unsupported response_type" do
+        expect { described_class.register(metadata: {redirect_uris: redirect_uris, response_types: %w(token)}) }
+          .to raise_error(described_class::ValidationError) { |e| expect(e.error_code).to eq(:invalid_client_metadata) }
+      end
+    end
+  end
+
+  describe "#active?" do
+    let(:now) { Time.at(1_700_000_000) }
+    subject(:client) { described_class.register(metadata: {redirect_uris: redirect_uris}, now: now) }
+
+    it "is active before expiry and inactive after" do
+      expect(client.active?(now)).to eq(true)
+      expect(client.active?(Time.at(client.expiry + 1))).to eq(false)
+    end
+  end
+
+  describe "JSON round-trip" do
+    subject(:client) do
+      described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'client_secret_basic', client_name: 'cli', scope: 'openid'})
+    end
+
+    it "includes ttl mirroring expiry in as_json" do
+      expect(client.as_json[:ttl]).to eq(client.expiry)
+    end
+
+    it "reconstructs an equivalent client (secret_hash persisted, plaintext not)" do
+      restored = described_class.from_json(client.as_json)
+      expect(restored.id).to eq(client.id)
+      expect(restored.secret).to be_nil
+      expect(restored.to_client_registration.match_secret?(client.secret)).to eq(true)
+      expect(restored.redirect_uris).to eq(client.redirect_uris)
+      expect(restored.client_name).to eq('cli')
+      expect(restored.expiry).to eq(client.expiry)
+    end
+  end
+
+  describe "#to_client_registration" do
+    it "produces a public ClientRegistration for token_endpoint_auth_method=none" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'none'})
+      registration = client.to_client_registration
+
+      expect(registration).to be_a(Himari::ClientRegistration)
+      expect(registration.id).to eq(client.id)
+      expect(registration.name).to be_nil
+      expect(registration.confidential?).to eq(false)
+      expect(registration.require_pkce).to eq(true)
+      expect(registration.match_secret?('anything')).to eq(false)
+      expect(registration.match_hint?(id: client.id)).to eq(true)
+    end
+
+    it "produces a confidential ClientRegistration carrying the secret hash" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'client_secret_basic'})
+      registration = client.to_client_registration
+
+      expect(registration.confidential?).to eq(true)
+      expect(registration.require_pkce).to eq(false)
+      expect(registration.match_secret?(client.secret)).to eq(true)
+    end
+  end
+end

--- a/himari/spec/himari/dynamic_client_registration_spec.rb
+++ b/himari/spec/himari/dynamic_client_registration_spec.rb
@@ -198,6 +198,30 @@ RSpec.describe Himari::DynamicClientRegistration do
     end
   end
 
+  describe "ignore_localhost_redirect_uri_port" do
+    it "defaults to true" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'none'})
+      expect(client.ignore_localhost_redirect_uri_port).to eq(true)
+    end
+
+    it "honours an override from the registration policy" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'none'}, ignore_localhost_redirect_uri_port: false)
+      expect(client.ignore_localhost_redirect_uri_port).to eq(false)
+    end
+
+    it "is not taken from client-supplied metadata" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'none', ignore_localhost_redirect_uri_port: false})
+      expect(client.ignore_localhost_redirect_uri_port).to eq(true)
+    end
+
+    it "round-trips through as_json/from_json and to_client_registration" do
+      client = described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'none'}, ignore_localhost_redirect_uri_port: false)
+      restored = described_class.from_json(client.as_json)
+      expect(restored.ignore_localhost_redirect_uri_port).to eq(false)
+      expect(restored.to_client_registration.ignore_localhost_redirect_uri_port).to eq(false)
+    end
+  end
+
   describe "JSON round-trip" do
     subject(:client) do
       described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'client_secret_basic', client_name: 'cli', scope: 'openid'})

--- a/himari/spec/himari/dynamic_client_registration_spec.rb
+++ b/himari/spec/himari/dynamic_client_registration_spec.rb
@@ -174,6 +174,30 @@ RSpec.describe Himari::DynamicClientRegistration do
     end
   end
 
+  describe "#as_log" do
+    subject(:client) do
+      described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'client_secret_basic', client_name: 'cli', client_uri: 'https://app.test.invalid/', scope: 'openid'})
+    end
+
+    it "exposes client metadata attributes without secrets" do
+      log = client.as_log
+      expect(log).to include(
+        id: client.id,
+        token_endpoint_auth_method: 'client_secret_basic',
+        redirect_uris: redirect_uris,
+        grant_types: client.grant_types,
+        response_types: client.response_types,
+        client_name: 'cli',
+        client_uri: 'https://app.test.invalid/',
+        scope: 'openid',
+        client_id_issued_at: client.client_id_issued_at,
+        expiry: client.expiry,
+        dynamic: true,
+      )
+      expect(log).not_to include(:secret, :secret_hash)
+    end
+  end
+
   describe "JSON round-trip" do
     subject(:client) do
       described_class.register(metadata: {redirect_uris: redirect_uris, token_endpoint_auth_method: 'client_secret_basic', client_name: 'cli', scope: 'openid'})

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -56,6 +56,18 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         expect(client.match_hint?(id: url)).to eq(true)
       end
 
+      it 'enables ignore_localhost_redirect_uri_port by default' do
+        expect(provider.collect(id: url).first.ignore_localhost_redirect_uri_port).to eq(true)
+      end
+
+      context 'with ignore_localhost_redirect_uri_port disabled' do
+        let(:options) { {ignore_localhost_redirect_uri_port: false} }
+
+        it 'carries the configured value onto the registration' do
+          expect(provider.collect(id: url).first.ignore_localhost_redirect_uri_port).to eq(false)
+        end
+      end
+
       context 'with a logger' do
         let(:logger) { instance_double('Logger') }
         let(:options) { {logger: logger} }

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         client = provider.collect(id: url).first
         expect(client.match_hint?(id: url)).to eq(true)
       end
+
+      context 'with a logger' do
+        let(:logger) { instance_double('Logger') }
+        let(:options) { {logger: logger} }
+
+        it 'logs the fetched client metadata' do
+          expect(logger).to receive(:info) do |line|
+            expect(line.message).to eq('OauthClientMetadata: fetched')
+            expect(line.data[:client_id]).to eq(url)
+            expect(line.data[:metadata]).to include(redirect_uris: %w(https://client.example.com/callback), token_endpoint_auth_method: 'none')
+          end
+          provider.collect(id: url)
+        end
+      end
     end
 
     context 'when no id hint is given' do

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -207,5 +207,26 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         provider.collect(id: url)
       end
     end
+
+    context 'when the cached total size exceeds the limit' do
+      # each document body is ~120 bytes, so a 200-byte budget holds at most one entry
+      let(:options) { {cache_max_total_size: 200} }
+
+      def doc_for(u)
+        {client_id: u, redirect_uris: %w(https://client.example.com/callback), token_endpoint_auth_method: 'none'}
+      end
+
+      it 'evicts the oldest entry so it must be re-fetched' do
+        url_a = 'https://a.example.com/meta'
+        url_b = 'https://b.example.com/meta'
+
+        expect(session).to receive(:get).with(url_a).and_return(ok_response(doc_for(url_a))).twice
+        allow(session).to receive(:get).with(url_b).and_return(ok_response(doc_for(url_b)))
+
+        provider.collect(id: url_a) # cached
+        provider.collect(id: url_b) # pushes total over the limit, evicts url_a (oldest)
+        provider.collect(id: url_a) # cache miss -> second fetch of url_a
+      end
+    end
   end
 end

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -4,10 +4,17 @@ require 'spec_helper'
 require 'himari/item_providers/oauth_client_metadata'
 
 RSpec.describe Himari::ItemProviders::OauthClientMetadata do
-  # Minimal stand-in for an HTTPX response. raise_for_status is a no-op on success.
+  # Minimal stand-in for a streaming HTTPX response. raise_for_status is a no-op on success;
+  # #each yields the body as a single chunk (the provider reads the body via streaming).
   FakeResponse = Struct.new(:status, :headers, :body) do
     def raise_for_status
       self
+    end
+
+    def each
+      return enum_for(:each) unless block_given?
+
+      yield body
     end
   end
 
@@ -31,7 +38,7 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
 
   describe '#collect' do
     context 'with a compliant client_id whose document is valid' do
-      before { allow(session).to receive(:get).with(url).and_return(ok_response(document)) }
+      before { allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document)) }
 
       it 'returns a public ClientRegistration that requires PKCE' do
         result = provider.collect(id: url)
@@ -108,13 +115,13 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
 
       it 'fetches an id matching a String entry' do
         allowed = 'https://allowed.example.com/meta'
-        allow(session).to receive(:get).with(allowed).and_return(ok_response(document.merge(client_id: allowed)))
+        allow(session).to receive(:get).with(allowed, stream: true).and_return(ok_response(document.merge(client_id: allowed)))
         expect(provider.collect(id: allowed).size).to eq(1)
       end
 
       it 'fetches an id matching a Regexp entry' do
         allowed = 'https://re.example.com/anything'
-        allow(session).to receive(:get).with(allowed).and_return(ok_response(document.merge(client_id: allowed)))
+        allow(session).to receive(:get).with(allowed, stream: true).and_return(ok_response(document.merge(client_id: allowed)))
         expect(provider.collect(id: allowed).size).to eq(1)
       end
 
@@ -126,46 +133,46 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
 
     context 'when the document is invalid' do
       it 'rejects when client_id does not match the URL' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(client_id: 'https://evil.example.com/x')))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document.merge(client_id: 'https://evil.example.com/x')))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects a shared-secret token_endpoint_auth_method' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(token_endpoint_auth_method: 'client_secret_basic')))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document.merge(token_endpoint_auth_method: 'client_secret_basic')))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects when client_secret is present' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(client_secret: 'nope')))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document.merge(client_secret: 'nope')))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects dangerous redirect_uri schemes' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(redirect_uris: %w(javascript:alert(1)))))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document.merge(redirect_uris: %w(javascript:alert(1)))))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects malformed JSON' do
-        allow(session).to receive(:get).with(url).and_return(ok_response('{not json', headers: {'content-type' => 'application/json'}))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response('{not json', headers: {'content-type' => 'application/json'}))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects a non-JSON content-type' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document, headers: {'content-type' => 'text/html'}))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document, headers: {'content-type' => 'text/html'}))
         expect(provider.collect(id: url)).to eq([])
       end
     end
 
     context 'with HTTP-level problems' do
       it 'rejects a non-200 status' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document, status: 302))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document, status: 302))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects when the transport raises (e.g. SSRF block)' do
         resp = instance_double('HTTPX::ErrorResponse')
         allow(resp).to receive(:raise_for_status).and_raise(HTTPX::Error.new('blocked'))
-        allow(session).to receive(:get).with(url).and_return(resp)
+        allow(session).to receive(:get).with(url, stream: true).and_return(resp)
         expect(provider.collect(id: url)).to eq([])
       end
     end
@@ -174,35 +181,55 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
       let(:options) { {max_response_size: 50} }
 
       it 'rejects when Content-Length exceeds the limit' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document, headers: {'content-length' => '999'}))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document, headers: {'content-length' => '999'}))
         expect(provider.collect(id: url)).to eq([])
       end
 
       it 'rejects when the body exceeds the limit' do
         # the document JSON is well over 50 bytes and carries no Content-Length header here
-        allow(session).to receive(:get).with(url).and_return(ok_response(document))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document))
         expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'aborts mid-stream once the cap is exceeded, without consuming the whole body' do
+        chunks_yielded = 0
+        streamed = Object.new
+        streamed.define_singleton_method(:status) { 200 }
+        streamed.define_singleton_method(:headers) { {'content-type' => 'application/json'} }
+        streamed.define_singleton_method(:raise_for_status) { self }
+        # No Content-Length; an unbounded chunked stream. The provider must stop reading shortly
+        # after the cap rather than draining this forever.
+        streamed.define_singleton_method(:each) do |&blk|
+          loop do
+            chunks_yielded += 1
+            blk.call('x' * 40)
+          end
+        end
+        allow(session).to receive(:get).with(url, stream: true).and_return(streamed)
+
+        expect(provider.collect(id: url)).to eq([])
+        expect(chunks_yielded).to eq(2) # 40 bytes ok, 80 bytes trips the 50-byte cap
       end
     end
 
     context 'caching' do
       it 'serves a second lookup from cache without re-fetching' do
-        expect(session).to receive(:get).with(url).once.and_return(ok_response(document, headers: {'cache-control' => 'max-age=300'}))
+        expect(session).to receive(:get).with(url, stream: true).once.and_return(ok_response(document, headers: {'cache-control' => 'max-age=300'}))
         first = provider.collect(id: url).first
         second = provider.collect(id: url).first
         expect(second).to equal(first)
       end
 
       it 'does not cache error responses' do
-        allow(session).to receive(:get).with(url).and_return(ok_response(document, status: 500))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document, status: 500))
         expect(provider.collect(id: url)).to eq([])
         # a subsequent success is served (proving the failure was not cached)
-        allow(session).to receive(:get).with(url).and_return(ok_response(document))
+        allow(session).to receive(:get).with(url, stream: true).and_return(ok_response(document))
         expect(provider.collect(id: url).size).to eq(1)
       end
 
       it 'does not cache when Cache-Control is no-store' do
-        expect(session).to receive(:get).with(url).twice.and_return(ok_response(document, headers: {'cache-control' => 'no-store'}))
+        expect(session).to receive(:get).with(url, stream: true).twice.and_return(ok_response(document, headers: {'cache-control' => 'no-store'}))
         provider.collect(id: url)
         provider.collect(id: url)
       end
@@ -220,8 +247,8 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         url_a = 'https://a.example.com/meta'
         url_b = 'https://b.example.com/meta'
 
-        expect(session).to receive(:get).with(url_a).and_return(ok_response(doc_for(url_a))).twice
-        allow(session).to receive(:get).with(url_b).and_return(ok_response(doc_for(url_b)))
+        expect(session).to receive(:get).with(url_a, stream: true).and_return(ok_response(doc_for(url_a))).twice
+        allow(session).to receive(:get).with(url_b, stream: true).and_return(ok_response(doc_for(url_b)))
 
         provider.collect(id: url_a) # cached
         provider.collect(id: url_b) # pushes total over the limit, evicts url_a (oldest)

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'himari/item_providers/oauth_client_metadata'
+
+RSpec.describe Himari::ItemProviders::OauthClientMetadata do
+  # Minimal stand-in for an HTTPX response. raise_for_status is a no-op on success.
+  FakeResponse = Struct.new(:status, :headers, :body) do
+    def raise_for_status
+      self
+    end
+  end
+
+  def ok_response(doc, headers: {}, status: 200)
+    body = doc.is_a?(String) ? doc : JSON.generate(doc)
+    FakeResponse.new(status, {'content-type' => 'application/json'}.merge(headers), body)
+  end
+
+  let(:url) { 'https://client.example.com/oauth/metadata' }
+  let(:document) do
+    {
+      client_id: url,
+      redirect_uris: %w(https://client.example.com/callback),
+      token_endpoint_auth_method: 'none',
+    }
+  end
+
+  let(:session) { instance_double('HTTPX::Session') }
+  let(:options) { {} }
+  let(:provider) { described_class.new(session: session, **options) }
+
+  describe '#collect' do
+    context 'with a compliant client_id whose document is valid' do
+      before { allow(session).to receive(:get).with(url).and_return(ok_response(document)) }
+
+      it 'returns a public ClientRegistration that requires PKCE' do
+        result = provider.collect(id: url)
+        expect(result.size).to eq(1)
+        client = result.first
+        expect(client).to be_a(Himari::ClientRegistration)
+        expect(client.id).to eq(url)
+        expect(client.redirect_uris).to eq(%w(https://client.example.com/callback))
+        expect(client.confidential?).to eq(false)
+        expect(client.require_pkce).to eq(true)
+      end
+
+      it 'matches the fetched client by hint' do
+        client = provider.collect(id: url).first
+        expect(client.match_hint?(id: url)).to eq(true)
+      end
+    end
+
+    context 'when no id hint is given' do
+      it 'returns [] without fetching' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect).to eq([])
+      end
+    end
+
+    context 'when the id is not a compliant client_id URL' do
+      it 'rejects non-URL ids without fetching' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: 'myclient1')).to eq([])
+      end
+
+      it 'rejects non-https URLs' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: 'http://client.example.com/meta')).to eq([])
+      end
+
+      it 'rejects URLs without a path' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: 'https://client.example.com')).to eq([])
+      end
+
+      it 'rejects URLs with a fragment' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: 'https://client.example.com/meta#x')).to eq([])
+      end
+
+      it 'rejects URLs with userinfo' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: 'https://user@client.example.com/meta')).to eq([])
+      end
+
+      it 'rejects URLs with dot path segments' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: 'https://client.example.com/../meta')).to eq([])
+      end
+    end
+
+    context 'with allowed_client_ids restrictions' do
+      let(:options) { {allowed_client_ids: ['https://allowed.example.com/meta', %r{\Ahttps://re\.example\.com/}]} }
+
+      it 'fetches an id matching a String entry' do
+        allowed = 'https://allowed.example.com/meta'
+        allow(session).to receive(:get).with(allowed).and_return(ok_response(document.merge(client_id: allowed)))
+        expect(provider.collect(id: allowed).size).to eq(1)
+      end
+
+      it 'fetches an id matching a Regexp entry' do
+        allowed = 'https://re.example.com/anything'
+        allow(session).to receive(:get).with(allowed).and_return(ok_response(document.merge(client_id: allowed)))
+        expect(provider.collect(id: allowed).size).to eq(1)
+      end
+
+      it 'rejects an id matching no entry without fetching' do
+        expect(session).not_to receive(:get)
+        expect(provider.collect(id: url)).to eq([])
+      end
+    end
+
+    context 'when the document is invalid' do
+      it 'rejects when client_id does not match the URL' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(client_id: 'https://evil.example.com/x')))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects a shared-secret token_endpoint_auth_method' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(token_endpoint_auth_method: 'client_secret_basic')))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects when client_secret is present' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(client_secret: 'nope')))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects dangerous redirect_uri schemes' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document.merge(redirect_uris: %w(javascript:alert(1)))))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects malformed JSON' do
+        allow(session).to receive(:get).with(url).and_return(ok_response('{not json', headers: {'content-type' => 'application/json'}))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects a non-JSON content-type' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document, headers: {'content-type' => 'text/html'}))
+        expect(provider.collect(id: url)).to eq([])
+      end
+    end
+
+    context 'with HTTP-level problems' do
+      it 'rejects a non-200 status' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document, status: 302))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects when the transport raises (e.g. SSRF block)' do
+        resp = instance_double('HTTPX::ErrorResponse')
+        allow(resp).to receive(:raise_for_status).and_raise(HTTPX::Error.new('blocked'))
+        allow(session).to receive(:get).with(url).and_return(resp)
+        expect(provider.collect(id: url)).to eq([])
+      end
+    end
+
+    context 'with response size limits' do
+      let(:options) { {max_response_size: 50} }
+
+      it 'rejects when Content-Length exceeds the limit' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document, headers: {'content-length' => '999'}))
+        expect(provider.collect(id: url)).to eq([])
+      end
+
+      it 'rejects when the body exceeds the limit' do
+        # the document JSON is well over 50 bytes and carries no Content-Length header here
+        allow(session).to receive(:get).with(url).and_return(ok_response(document))
+        expect(provider.collect(id: url)).to eq([])
+      end
+    end
+
+    context 'caching' do
+      it 'serves a second lookup from cache without re-fetching' do
+        expect(session).to receive(:get).with(url).once.and_return(ok_response(document, headers: {'cache-control' => 'max-age=300'}))
+        first = provider.collect(id: url).first
+        second = provider.collect(id: url).first
+        expect(second).to equal(first)
+      end
+
+      it 'does not cache error responses' do
+        allow(session).to receive(:get).with(url).and_return(ok_response(document, status: 500))
+        expect(provider.collect(id: url)).to eq([])
+        # a subsequent success is served (proving the failure was not cached)
+        allow(session).to receive(:get).with(url).and_return(ok_response(document))
+        expect(provider.collect(id: url).size).to eq(1)
+      end
+
+      it 'does not cache when Cache-Control is no-store' do
+        expect(session).to receive(:get).with(url).twice.and_return(ok_response(document, headers: {'cache-control' => 'no-store'}))
+        provider.collect(id: url)
+        provider.collect(id: url)
+      end
+    end
+  end
+end

--- a/himari/spec/himari/item_providers/storage_spec.rb
+++ b/himari/spec/himari/item_providers/storage_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'himari/item_providers/storage'
+require 'himari/storages/memory'
+require 'himari/dynamic_client_registration'
+
+RSpec.describe Himari::ItemProviders::Storage do
+  subject(:provider) { described_class.new(storage: storage) }
+
+  let(:storage) { Himari::Storages::Memory.new }
+  let(:client) { Himari::DynamicClientRegistration.register(metadata: {redirect_uris: %w(https://rp.test.invalid/cb), token_endpoint_auth_method: 'none'}) }
+
+  before { storage.put_dynamic_client(client) }
+
+  it "returns the client (as a ClientRegistration) for a matching id hint" do
+    collected = provider.collect(id: client.id)
+    expect(collected.map(&:id)).to eq([client.id])
+    expect(collected.first).to be_a(Himari::ClientRegistration)
+  end
+
+  it "returns nothing without an id hint" do
+    expect(provider.collect).to eq([])
+  end
+
+  it "returns nothing for an unknown id" do
+    expect(provider.collect(id: 'unknown')).to eq([])
+  end
+
+  it "filters out expired registrations" do
+    expired = Himari::DynamicClientRegistration.register(metadata: {redirect_uris: %w(https://rp.test.invalid/cb)}, now: Time.at(1))
+    storage.put_dynamic_client(expired)
+    expect(provider.collect(id: expired.id)).to eq([])
+  end
+end

--- a/himari/spec/himari/middlewares/dynamic_clients_spec.rb
+++ b/himari/spec/himari/middlewares/dynamic_clients_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'himari/middlewares/dynamic_clients'
+require 'himari/middlewares/config'
+require 'himari/middlewares/client'
+require 'himari/storages/memory'
+
+RSpec.describe Himari::Middlewares::DynamicClients do
+  let(:storage) { Himari::Storages::Memory.new }
+  let(:config) { double('config', storage: storage) }
+  let(:downstream) { ->(_env) { [200, {}, ['ok']] } }
+  subject(:middleware) { described_class.new(downstream) }
+
+  def env_with_config
+    {Himari::Middlewares::Config::RACK_KEY => config}
+  end
+
+  it "sets the enable flag and appends a storage provider to the client chain" do
+    env = env_with_config
+    middleware.call(env)
+
+    expect(env[described_class::RACK_KEY]).to be_a(described_class::Options)
+    expect(env[Himari::Middlewares::Client::RACK_KEY].last).to be_a(Himari::ItemProviders::Storage)
+  end
+
+  it "defaults registration_lifetime to the model default" do
+    env = env_with_config
+    middleware.call(env)
+    expect(env[described_class::RACK_KEY].registration_lifetime).to eq(Himari::DynamicClientRegistration::REGISTRATION_LIFETIME)
+  end
+
+  it "honors a configured registration_lifetime" do
+    env = env_with_config
+    described_class.new(downstream, registration_lifetime: 3600).call(env)
+    expect(env[described_class::RACK_KEY].registration_lifetime).to eq(3600)
+  end
+
+  it "preserves existing static client providers" do
+    env = env_with_config.merge(Himari::Middlewares::Client::RACK_KEY => [:static_provider])
+    middleware.call(env)
+
+    expect(env[Himari::Middlewares::Client::RACK_KEY].first).to eq(:static_provider)
+    expect(env[Himari::Middlewares::Client::RACK_KEY].size).to eq(2)
+  end
+
+  it "raises when Config middleware did not run first" do
+    expect { middleware.call({}) }.to raise_error(/after Himari::Middlewares::Config/)
+  end
+end

--- a/himari/spec/himari/middlewares/metadata_clients_spec.rb
+++ b/himari/spec/himari/middlewares/metadata_clients_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'himari/middlewares/metadata_clients'
+require 'himari/middlewares/config'
+require 'himari/middlewares/client'
+require 'himari/storages/memory'
+
+RSpec.describe Himari::Middlewares::MetadataClients do
+  let(:storage) { Himari::Storages::Memory.new }
+  let(:config) { double('config', storage: storage) }
+  let(:downstream) { ->(_env) { [200, {}, ['ok']] } }
+  subject(:middleware) { described_class.new(downstream) }
+
+  def env_with_config
+    {Himari::Middlewares::Config::RACK_KEY => config}
+  end
+
+  it "sets the enable flag and appends a metadata provider to the client chain" do
+    env = env_with_config
+    middleware.call(env)
+
+    expect(env[described_class::RACK_KEY]).to be_a(described_class::Options)
+    expect(env[Himari::Middlewares::Client::RACK_KEY].last).to be_a(Himari::ItemProviders::OauthClientMetadata)
+  end
+
+  it "reuses the same provider instance across requests (session/cache retained)" do
+    env1 = env_with_config
+    env2 = env_with_config
+    middleware.call(env1)
+    middleware.call(env2)
+
+    expect(env1[Himari::Middlewares::Client::RACK_KEY].last).to equal(env2[Himari::Middlewares::Client::RACK_KEY].last)
+  end
+
+  it "defaults to requiring PKCE and accepting any compliant client_id" do
+    env = env_with_config
+    middleware.call(env)
+    expect(env[described_class::RACK_KEY].require_pkce).to eq(true)
+    expect(env[described_class::RACK_KEY].allowed_client_ids).to eq([])
+  end
+
+  it "honors configured options" do
+    env = env_with_config
+    described_class.new(downstream, require_pkce: false, allowed_client_ids: ['https://x.example/m'], max_response_size: 1024).call(env)
+    opts = env[described_class::RACK_KEY]
+    expect(opts.require_pkce).to eq(false)
+    expect(opts.allowed_client_ids).to eq(['https://x.example/m'])
+    expect(opts.max_response_size).to eq(1024)
+  end
+
+  it "preserves existing static client providers" do
+    env = env_with_config.merge(Himari::Middlewares::Client::RACK_KEY => [:static_provider])
+    middleware.call(env)
+
+    expect(env[Himari::Middlewares::Client::RACK_KEY].first).to eq(:static_provider)
+    expect(env[Himari::Middlewares::Client::RACK_KEY].size).to eq(2)
+  end
+
+  it "raises when Config middleware did not run first" do
+    expect { middleware.call({}) }.to raise_error(/after Himari::Middlewares::Config/)
+  end
+
+  it "rejects an invalid ssrf option at build time" do
+    expect { described_class.new(downstream, ssrf: :bogus) }.to raise_error(ArgumentError, /ssrf option/)
+  end
+end

--- a/himari/spec/himari/services/client_registration_endpoint_spec.rb
+++ b/himari/spec/himari/services/client_registration_endpoint_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/null_logger'
+require 'himari/services/client_registration_endpoint'
+require 'himari/storages/memory'
+
+RSpec.describe Himari::Services::ClientRegistrationEndpoint do
+  include Rack::Test::Methods
+
+  let(:storage) { Himari::Storages::Memory.new }
+  let(:logger) { Rack::NullLogger.new(nil) }
+  let(:app) { described_class.new(storage: storage, logger: logger) }
+
+  def register(body)
+    post '/oidc/register', JSON.generate(body), {'CONTENT_TYPE' => 'application/json'}
+  end
+
+  context "registering a public client" do
+    it "returns 201 without a client_secret and persists it" do
+      register(redirect_uris: %w(https://rp.test.invalid/cb), token_endpoint_auth_method: 'none')
+      expect(last_response.status).to eq(201)
+      expect(last_response.content_type).to eq('application/json')
+
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body[:client_id]).to be_a(String)
+      expect(body).not_to have_key(:client_secret)
+      expect(body[:token_endpoint_auth_method]).to eq('none')
+
+      stored = storage.find_dynamic_client(body[:client_id])
+      expect(stored).not_to be_nil
+      expect(stored.confidential?).to eq(false)
+    end
+  end
+
+  context "registering a confidential client" do
+    it "returns 201 with a one-time client_secret" do
+      register(redirect_uris: %w(https://rp.test.invalid/cb), token_endpoint_auth_method: 'client_secret_basic')
+      expect(last_response.status).to eq(201)
+
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body[:client_secret]).to be_a(String)
+      expect(body[:client_secret_expires_at]).to be_a(Integer)
+
+      stored = storage.find_dynamic_client(body[:client_id])
+      expect(stored.to_client_registration.match_secret?(body[:client_secret])).to eq(true)
+    end
+  end
+
+  context "with invalid redirect_uris" do
+    it "returns 400 invalid_redirect_uri" do
+      register(redirect_uris: [])
+      expect(last_response.status).to eq(400)
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body[:error]).to eq('invalid_redirect_uri')
+    end
+  end
+
+  context "with unsupported metadata" do
+    it "returns 400 invalid_client_metadata" do
+      register(redirect_uris: %w(https://rp.test.invalid/cb), grant_types: %w(client_credentials))
+      expect(last_response.status).to eq(400)
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body[:error]).to eq('invalid_client_metadata')
+    end
+  end
+
+  context "with a non-JSON content type" do
+    it "returns 400" do
+      post '/oidc/register', 'redirect_uris=x', {'CONTENT_TYPE' => 'application/x-www-form-urlencoded'}
+      expect(last_response.status).to eq(400)
+    end
+  end
+
+  context "with a GET request" do
+    it "returns 405" do
+      get '/oidc/register'
+      expect(last_response.status).to eq(405)
+    end
+  end
+end

--- a/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
@@ -6,6 +6,7 @@ require 'base64'
 require 'addressable'
 require 'rack/null_logger'
 require 'himari/services/oidc_authorization_endpoint'
+require 'himari/client_registration'
 require 'himari/storages/memory'
 require 'himari/authorization_code'
 
@@ -14,7 +15,8 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
 
   let(:authz) { Himari::AuthorizationCode.make(client_id: 'clientid', claims: {sub: 'chihiro'}) }
   let(:require_pkce) { false }
-  let(:client) { double('client', id: 'clientid', redirect_uris: ['https://rp.invalid/cb'], as_log: {client_as_log: 1}, require_pkce:) }
+  let(:redirect_uris) { ['https://rp.invalid/cb'] }
+  let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:) }
   let(:storage) { Himari::Storages::Memory.new }
   let(:logger) { Rack::NullLogger.new(nil) }
 
@@ -163,6 +165,34 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
       get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
       stored = storage.find_authorization(Addressable::URI.parse(last_response.headers['location']).query_values['code'])
       expect(stored.offline_access).to eq(false)
+    end
+  end
+
+  context "with a mismatched redirect_uri" do
+    it "returns invalid_request without redirecting" do
+      get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Fattacker.invalid%2Fcb&nonce=nn'
+      expect(last_response.status).to eq(400)
+    end
+  end
+
+  context "with a loopback redirect_uri using an ephemeral port" do
+    let(:redirect_uris) { ['http://127.0.0.1/cb'] }
+
+    it "accepts any port and stores the actual redirect_uri" do
+      get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcb&nonce=nn'
+      expect(last_response.status).to eq(302)
+      query = Addressable::URI.parse(last_response.headers['location']).query_values
+      stored = storage.find_authorization(query['code'])
+      expect(stored.redirect_uri).to eq('http://127.0.0.1:54321/cb')
+    end
+
+    context "when ignore_localhost_redirect_uri_port is disabled" do
+      let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, ignore_localhost_redirect_uri_port: false) }
+
+      it "rejects a differing port" do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcb&nonce=nn'
+        expect(last_response.status).to eq(400)
+      end
     end
   end
 end

--- a/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
 
   let(:signing_key_provider) { double('chain', collect: keys) }
   let(:registration_endpoint) { nil }
-  let(:app) { described_class.new(signing_key_provider: signing_key_provider, issuer: 'https://test.invalid', registration_endpoint: registration_endpoint) }
+  let(:client_id_metadata_document_supported) { false }
+  let(:app) { described_class.new(signing_key_provider: signing_key_provider, issuer: 'https://test.invalid', registration_endpoint: registration_endpoint, client_id_metadata_document_supported: client_id_metadata_document_supported) }
 
   context "with non-GET request" do
     it "returns 404" do
@@ -49,6 +50,24 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
           get '/.well-known/openid-configuration'
           body = JSON.parse(last_response.body, symbolize_names: true)
           expect(body[:registration_endpoint]).to eq('https://test.invalid/public/oidc/register')
+        end
+      end
+
+      context "without metadata client registrations" do
+        it "omits client_id_metadata_document_supported" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body).not_to have_key(:client_id_metadata_document_supported)
+        end
+      end
+
+      context "with metadata client registrations" do
+        let(:client_id_metadata_document_supported) { true }
+
+        it "advertises client_id_metadata_document_supported" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body[:client_id_metadata_document_supported]).to eq(true)
         end
       end
     end

--- a/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
   end
 
   let(:signing_key_provider) { double('chain', collect: keys) }
-  let(:app) { described_class.new(signing_key_provider: signing_key_provider, issuer: 'https://test.invalid') }
+  let(:registration_endpoint) { nil }
+  let(:app) { described_class.new(signing_key_provider: signing_key_provider, issuer: 'https://test.invalid', registration_endpoint: registration_endpoint) }
 
   context "with non-GET request" do
     it "returns 404" do
@@ -31,6 +32,24 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
         body = JSON.parse(last_response.body, symbolize_names: true)
 
         expect(body[:id_token_signing_alg_values_supported]).to eq(%w(RS256))
+      end
+
+      context "without dynamic client registration" do
+        it "omits registration_endpoint" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body).not_to have_key(:registration_endpoint)
+        end
+      end
+
+      context "with dynamic client registration" do
+        let(:registration_endpoint) { 'https://test.invalid/public/oidc/register' }
+
+        it "advertises registration_endpoint" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body[:registration_endpoint]).to eq('https://test.invalid/public/oidc/register')
+        end
       end
     end
 

--- a/himari/spec/himari/services/oidc_token_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_token_endpoint_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
 
   let(:require_pkce) { false }
 
+  let(:confidential) { true }
   let(:client) do
-    double('client', id: 'clientid', redirect_uris: ['https://rp.invalid/cb'], preferred_key_group: 'kagi', as_log: {client_as_log: 1}, require_pkce: require_pkce).tap do |x|
+    double('client', id: 'clientid', redirect_uris: ['https://rp.invalid/cb'], preferred_key_group: 'kagi', as_log: {client_as_log: 1}, require_pkce: require_pkce, confidential?: confidential).tap do |x|
       allow(x).to receive(:match_secret?).with('secret').and_return(true)
     end
   end
@@ -145,6 +146,35 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
         expect(last_response.status).to eq(200)
         expect(last_response.content_type).to match(%r{^application/json})
       end
+    end
+  end
+
+  context "with grant issued to a different client" do
+    let(:authz) { Himari::AuthorizationCode.make(client_id: 'otherclient', claims: {sub: 'chihiro'}, redirect_uri: 'https://rp.invalid/cb', openid: scope_openid, lifetime: lifetime_value) }
+
+    it "returns 400" do
+      post '/oidc/token', 'grant_type' => 'authorization_code', 'code' => authz.code, 'redirect_uri' => 'https://rp.invalid/cb'
+      expect(last_response.status).to eq(400)
+    end
+  end
+
+  context "with a public client (token_endpoint_auth_method=none)" do
+    let(:confidential) { false }
+    let(:require_pkce) { true }
+    let(:code_verifier) { 'kakunin' }
+    let(:code_challenge) { Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false) }
+    let(:authz) { Himari::AuthorizationCode.make(client_id: 'clientid', claims: {sub: 'chihiro'}, redirect_uri: 'https://rp.invalid/cb', openid: false, code_challenge: code_challenge, code_challenge_method: 'S256', lifetime: lifetime_value) }
+
+    before { allow(client_provider).to receive(:find).with(id: 'clientid').and_return(client) }
+
+    it "issues tokens with PKCE and no client secret" do
+      post '/oidc/token', {'grant_type' => 'authorization_code', 'code' => authz.code, 'redirect_uri' => 'https://rp.invalid/cb', 'code_verifier' => code_verifier, 'client_id' => 'clientid'}, {}
+      expect(last_response.status).to eq(200)
+    end
+
+    it "rejects when PKCE verifier is missing" do
+      post '/oidc/token', {'grant_type' => 'authorization_code', 'code' => authz.code, 'redirect_uri' => 'https://rp.invalid/cb', 'client_id' => 'clientid'}, {}
+      expect(last_response.status).to eq(400)
     end
   end
 

--- a/himari/spec/himari/storages/memory_spec.rb
+++ b/himari/spec/himari/storages/memory_spec.rb
@@ -3,9 +3,32 @@
 require 'spec_helper'
 require 'himari/storages/memory'
 require 'himari/refresh_token'
+require 'himari/dynamic_client_registration'
 
 RSpec.describe Himari::Storages::Memory do
   subject(:storage) { described_class.new }
+
+  describe "dynamic clients" do
+    let(:client) { Himari::DynamicClientRegistration.register(metadata: {redirect_uris: %w(https://rp.test.invalid/cb), token_endpoint_auth_method: 'client_secret_basic'}) }
+
+    it "round-trips put/find/delete by id" do
+      storage.put_dynamic_client(client)
+      found = storage.find_dynamic_client(client.id)
+      expect(found.id).to eq(client.id)
+      expect(found.to_client_registration.match_secret?(client.secret)).to eq(true)
+
+      storage.delete_dynamic_client(client)
+      expect(storage.find_dynamic_client(client.id)).to be_nil
+    end
+
+    it "returns nil for an unknown id" do
+      expect(storage.find_dynamic_client('nope')).to be_nil
+    end
+
+    it "returns nil (without reading storage) for an id with disallowed characters" do
+      expect(storage.find_dynamic_client('../authz/code')).to be_nil
+    end
+  end
 
   let(:token) do
     Himari::RefreshToken.make(client_id: 'cli', claims: {sub: 'c'}, session_handle: 'sess', openid: false, lifetime: 7200)


### PR DESCRIPTION
Adds runtime client registration to Himari and replaces rack-oauth2's redirect_uri verification with our own implementation.

## Client registration

- **`dynamic-clients`** — RFC 7591 OAuth 2.0 Dynamic Client Registration. A `POST /(public/)oidc/register` endpoint mints a `Himari::DynamicClientRegistration` persisted in storage; registered clients resolve through the same `client_provider.find(id:)` lookup the OIDC endpoints already use. Enabled (and advertised in discovery) by the `DynamicClients` middleware.
- **`metadata-clients`** — OAuth Client ID Metadata Document support (draft-ietf-oauth-client-id-metadata-document). A client_id that is an https URL is fetched on demand, validated, and presented as a public `ClientRegistration`. The provider keeps a persistent SSRF-filtered HTTPX session, caches documents within HTTP cache bounds, caps the fetched body during streaming read, and fails closed.
- **`metadata`** — serves RFC 8414 oauth-authorization-server discovery alongside OIDC discovery.

## redirect_uri matching

Native and CLI apps following RFC 8252 §7.3 / draft-ietf-oauth-v2-1-15 §8.4.2 bind an ephemeral loopback port at request time, which exact comparison cannot accommodate. The authorization endpoint no longer uses rack-oauth2's `verify_redirect_uri!`; instead `ClientRegistration#redirect_uri_covers?` (built on Addressable::URI) does:

- simple string comparison (RFC 3986 §6.2.1) with a port-ignoring exception for http/https loopback hosts (`localhost`, `127.0.0.1`, `[::1]`), gated by the new `ignore_localhost_redirect_uri_port` client attribute (default true);
- Regexp entries in `redirect_uris` (operator-supplied via static config) matched with `#match?`.

The flag is a deployment policy, not client-supplied metadata: dynamic registrations take it from the `DynamicClients` middleware and persist it; metadata clients take it from the `MetadataClients` middleware. The token endpoint is unchanged — the concrete port the client used is stored on the auth code, so its exact match stays correct.

Docs added under `docs/` for both registration mechanisms.