### PR TITLE
authorize: consent page gated by skip_consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ use(Himari::Middlewares::Client,
   secret_hash: '...', # sha384 hexdigest of secret
   # secret: '...' # or in cleartext
   redirect_uris: %w(https://app.example.net/oauth2/idpresponse),
+
+      # skip_consent: false # requires consent. default to true
+
   # Entries are matched by simple string comparison. A Regexp entry is matched
   # with #match? against the request redirect_uri instead, e.g.
   #   redirect_uris: [%r{\Ahttps://app\.example\.net/oauth2/[^/]+\z}]
@@ -154,7 +157,6 @@ Himari acts as an OIDC OpenID Provider. OIDC discovery metadata served at `/.wel
 
 ## Caveats
 
-- Consent/Authorize screen is not implemented. All authorization requests will be immediately approved on behalf of a logged in user, as long as AuthorizationRule permits.
 - Recognizes `openid` scope only.
 - Implements Authorization Code Grant Flow and [Refresh Token Grant Flow](./docs/refresh-tokens.md) only. Public clients should use the same flow with PKCE.
 

--- a/dev/config.rp.ru
+++ b/dev/config.rp.ru
@@ -21,6 +21,13 @@ class App < Sinatra::Base
       %(<input type="hidden" name="authenticity_token" value="#{Rack::Protection::AuthenticityToken.token(session)}">)
     end
 
+    # A login button; prompt is forwarded to the OP authorize request (the strategy reads
+    # request.GET['prompt']), letting you force the consent page on a skip_consent client.
+    def login_button(label, prompt: nil)
+      action = "/auth/himari#{prompt ? "?prompt=#{prompt}" : ""}"
+      %(<form action="#{action}" method=POST style="display:inline">#{csrf}<button>#{Rack::Utils.escape_html(label)}</button></form>)
+    end
+
     def render_signed_in(creds)
       <<~HTML
         <h2>session credentials</h2>
@@ -46,7 +53,10 @@ class App < Sinatra::Base
     creds = session[:credentials]
     <<~HTML
       <h1>himari dev RP</h1>
-      <form action=/auth/himari method=POST>#{csrf}<button>Log in</button></form>
+      <p>
+        #{login_button("Log in")}
+        #{login_button("Log in (prompt=consent)", prompt: "consent")}
+      </p>
       #{creds ? render_signed_in(creds) : "<p>not signed in</p>"}
     HTML
   end

--- a/dev/config.ru
+++ b/dev/config.ru
@@ -41,6 +41,11 @@ use(
         </small>
       </p>
     EOH
+    # Friendly labels for the consent page scope list (msg(:"scope_#{name}", name)).
+    scope_openid: 'Sign you in',
+    scope_offline_access: 'Keep you signed in while offline',
+    scope_profile: 'Your profile information',
+    scope_email: 'Your email address',
   },
 )
 
@@ -69,7 +74,9 @@ if File.exist?(File.join(__dir__, 'tmp/ec.pem'))
   )
 end
 
-# Add clients as many as you need
+# Add clients as many as you need.
+# skip_consent: true so a normal login skips the consent page; the RP's "prompt=consent" button
+# then forces it, exercising both paths with a single client.
 use(
   Himari::Middlewares::Client,
   name: 'client1', # friendly name (this can be referenced from policies)
@@ -77,6 +84,7 @@ use(
   secret: 'himitsudayo1',
   redirect_uris: %w(http://himari-rp.localhost:1355/auth/himari/callback),
   preferred_key_group: nil,
+  skip_consent: true,
 )
 
 # Enable RFC 7591 Dynamic Client Registration (POST /public/oidc/register). Registered

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -91,7 +91,15 @@ module Himari
           request.path
         else
           Addressable::URI.parse(request.fullpath).tap do |u|
-            u.query_values = u.query_values.reject { |k, _v| k == 'prompt' }
+            # Drop only the prompt values that would re-trigger the login screen once the user
+            # comes back authenticated (otherwise we'd loop); keep the rest (e.g. consent) so they
+            # still apply at the authorize endpoint after login.
+            u.query_values = u.query_values.filter_map do |k, v|
+              next [k, v] unless k == 'prompt'
+
+              remaining = v.to_s.split(/\s+/) - %w(login select_account)
+              [k, remaining.join(' ')] unless remaining.empty?
+            end.to_h
           end.to_s
         end
         query = Addressable::URI.form_encode(back_to: back_to)
@@ -156,7 +164,10 @@ module Himari
       "Himari #{release_code}\n"
     end
 
-    get '/oidc/authorize' do
+    # Served on GET (initial request and consent display) and POST (consent submission). The
+    # consent form posts the original authorization params back here as hidden fields plus a
+    # _consent decision; everything else flows through OidcAuthorizationEndpoint identically.
+    authorize_ep = proc do
       client = client_provider.find(id: params[:client_id])
       unless client
         logger&.warn(Himari::LogLine.new('authorize: no client registration found', req: request_as_log, client_id: params[:client_id]))
@@ -176,10 +187,16 @@ module Himari
           session_handle: current_user.handle,
         )
 
+        consent = case params[:_consent]
+        when 'approve' then :approve
+        when 'deny' then :deny
+        end
+
         Himari::Services::OidcAuthorizationEndpoint.new(
           authz: authz,
           client: client,
           storage: config.storage,
+          consent: consent,
           logger: logger,
         ).call(env)
       else
@@ -189,6 +206,11 @@ module Himari
     rescue Himari::Services::OidcAuthorizationEndpoint::ReauthenticationRequired
       logger&.warn(Himari::LogLine.new('authorize: prompt login to reauthenticate (demanded by oidc request)', req: request_as_log, session: current_user&.as_log, allowed: decision&.authz_result&.allowed, result: decision&.as_log))
       next erb(config.custom_templates[:login] || :login)
+    rescue Himari::Services::OidcAuthorizationEndpoint::ConsentRequired => e
+      logger&.info(Himari::LogLine.new('authorize: prompt consent', req: request_as_log, session: current_user&.as_log, client: e.client.as_log, scopes: e.scopes))
+      @consent_client = e.client
+      @consent_scopes = e.scopes
+      next erb(config.custom_templates[:consent] || :consent)
     rescue Himari::Services::DownstreamAuthorization::ForbiddenError => e
       logger&.warn(Himari::LogLine.new('authorize: downstream forbidden', req: request_as_log, session: current_user&.as_log, allowed: e.result.authz_result.allowed, err: e.class.inspect, result: e.as_log))
 
@@ -206,6 +228,8 @@ module Himari
 
       halt(403, "Forbidden#{message_human ? "; #{message_human}" : nil}")
     end
+    get '/oidc/authorize', &authorize_ep
+    post '/oidc/authorize', &authorize_ep
 
     token_ep = proc do
       Himari::Services::OidcTokenEndpoint.new(

--- a/himari/lib/himari/client_registration.rb
+++ b/himari/lib/himari/client_registration.rb
@@ -9,7 +9,7 @@ module Himari
     # draft-ietf-oauth-v2-1-15 §8.4.2). Addressable returns IPv6 hosts bracketed.
     LOOPBACK_HOSTS = %w[127.0.0.1 [::1] localhost].freeze
 
-    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true, ignore_localhost_redirect_uri_port: true)
+    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true, ignore_localhost_redirect_uri_port: true, skip_consent: false)
       @name = name
       @id = id
       @secret = secret
@@ -19,12 +19,13 @@ module Himari
       @require_pkce = require_pkce
       @confidential = confidential
       @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
+      @skip_consent = skip_consent
 
       raise ArgumentError, "name starts with '_' is reserved" if @name&.start_with?('_')
       raise ArgumentError, "either secret or secret_hash must be present" if confidential && !@secret && !@secret_hash
     end
 
-    attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce, :ignore_localhost_redirect_uri_port
+    attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce, :ignore_localhost_redirect_uri_port, :skip_consent
 
     def confidential?
       @confidential
@@ -57,7 +58,7 @@ module Himari
     end
 
     def as_log
-      {name: name, id: id}
+      {name: name, id: id, skip_consent: skip_consent}
     end
 
     def match_hint?(id: nil)

--- a/himari/lib/himari/dynamic_client_registration.rb
+++ b/himari/lib/himari/dynamic_client_registration.rb
@@ -175,10 +175,9 @@ module Himari
 
     # The client object the OIDC authorization/token endpoints consume. Dynamic records carry
     # no name (so operator rules keyed on name never match them) and pass through the secret
-    # hash only for confidential clients. Consent is skipped: dynamically registered clients are
-    # programmatic and cannot be vetted by an operator, so an interactive grant per request is
-    # impractical (prompt=consent still forces the page).
-    def to_client_registration
+    # hash only for confidential clients. skip_consent defaults to false and is supplied by the
+    # provider from the DynamicClients middleware option.
+    def to_client_registration(skip_consent: false)
       ClientRegistration.new(
         id: id,
         redirect_uris: redirect_uris,
@@ -187,7 +186,7 @@ module Himari
         require_pkce: require_pkce,
         confidential: confidential?,
         ignore_localhost_redirect_uri_port: ignore_localhost_redirect_uri_port,
-        skip_consent: true,
+        skip_consent: skip_consent,
       )
     end
 

--- a/himari/lib/himari/dynamic_client_registration.rb
+++ b/himari/lib/himari/dynamic_client_registration.rb
@@ -175,7 +175,9 @@ module Himari
 
     # The client object the OIDC authorization/token endpoints consume. Dynamic records carry
     # no name (so operator rules keyed on name never match them) and pass through the secret
-    # hash only for confidential clients.
+    # hash only for confidential clients. Consent is skipped: dynamically registered clients are
+    # programmatic and cannot be vetted by an operator, so an interactive grant per request is
+    # impractical (prompt=consent still forces the page).
     def to_client_registration
       ClientRegistration.new(
         id: id,
@@ -185,6 +187,7 @@ module Himari
         require_pkce: require_pkce,
         confidential: confidential?,
         ignore_localhost_redirect_uri_port: ignore_localhost_redirect_uri_port,
+        skip_consent: true,
       )
     end
 

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -150,6 +150,7 @@ module Himari
           confidential: false,
           require_pkce: @require_pkce,
           ignore_localhost_redirect_uri_port: @ignore_localhost_redirect_uri_port,
+          skip_consent: true,
         )
       end
 

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -34,12 +34,14 @@ module Himari
       # @param session [HTTPX::Session] persistent, SSRF-filtered session (built by the middleware)
       # @param allowed_client_ids [Array<String, Regexp>] empty = allow any compliant https URL
       def initialize(session:, allowed_client_ids: [], require_pkce: true, ignore_localhost_redirect_uri_port: true,
+        skip_consent: false,
         max_response_size: 5120,
         cache_min_ttl: 60, cache_max_ttl: 86400, cache_default_ttl: 300, cache_max_total_size: 1_048_576, logger: nil)
         @session = session
         @allowed_client_ids = allowed_client_ids
         @require_pkce = require_pkce
         @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
+        @skip_consent = skip_consent
         @max_response_size = max_response_size
         @cache_min_ttl = cache_min_ttl
         @cache_max_ttl = cache_max_ttl
@@ -150,7 +152,7 @@ module Himari
           confidential: false,
           require_pkce: @require_pkce,
           ignore_localhost_redirect_uri_port: @ignore_localhost_redirect_uri_port,
-          skip_consent: true,
+          skip_consent: @skip_consent,
         )
       end
 

--- a/himari/lib/himari/item_providers/storage.rb
+++ b/himari/lib/himari/item_providers/storage.rb
@@ -13,15 +13,17 @@ module Himari
       include Himari::ItemProvider
 
       # @param storage [Himari::Storages::Base]
-      def initialize(storage:)
+      # @param skip_consent [Boolean] applied to every dynamic client this provider resolves
+      def initialize(storage:, skip_consent: false)
         @storage = storage
+        @skip_consent = skip_consent
       end
 
       def collect(id: nil, **_hint)
         return [] unless id
 
         client = @storage.find_dynamic_client(id)
-        client&.active? ? [client.to_client_registration] : []
+        client&.active? ? [client.to_client_registration(skip_consent: @skip_consent)] : []
       end
     end
   end

--- a/himari/lib/himari/middlewares/dynamic_clients.rb
+++ b/himari/lib/himari/middlewares/dynamic_clients.rb
@@ -17,16 +17,18 @@ module Himari
     class DynamicClients
       RACK_KEY = 'himari.dynamic_clients'
 
-      Options = Data.define(:registration_lifetime, :ignore_localhost_redirect_uri_port, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
+      Options = Data.define(:registration_lifetime, :ignore_localhost_redirect_uri_port, :skip_consent, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
 
       # @param registration_lifetime [Integer] seconds a registration stays valid (default 180 days)
       # @param ignore_localhost_redirect_uri_port [Boolean] relax the port of loopback redirect_uris
       #   for registered clients (default true; see RFC 8252 §7.3)
+      # @param skip_consent [Boolean] let registered clients bypass the consent page (default false)
       def initialize(app, kwargs = {})
         @app = app
         @options = Options.new(
           registration_lifetime: kwargs.fetch(:registration_lifetime) { Himari::DynamicClientRegistration::REGISTRATION_LIFETIME },
           ignore_localhost_redirect_uri_port: kwargs.fetch(:ignore_localhost_redirect_uri_port, true),
+          skip_consent: kwargs.fetch(:skip_consent, false),
           grant_types_supported: Himari::DynamicClientRegistration::SUPPORTED_GRANT_TYPES,
           response_types_supported: Himari::DynamicClientRegistration::SUPPORTED_RESPONSE_TYPES,
           token_endpoint_auth_methods_supported: Himari::DynamicClientRegistration::SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,
@@ -41,7 +43,7 @@ module Himari
 
         env[RACK_KEY] = @options
         env[Himari::Middlewares::Client::RACK_KEY] ||= []
-        env[Himari::Middlewares::Client::RACK_KEY] += [Himari::ItemProviders::Storage.new(storage: config.storage)]
+        env[Himari::Middlewares::Client::RACK_KEY] += [Himari::ItemProviders::Storage.new(storage: config.storage, skip_consent: @options.skip_consent)]
 
         @app.call(env)
       end

--- a/himari/lib/himari/middlewares/metadata_clients.rb
+++ b/himari/lib/himari/middlewares/metadata_clients.rb
@@ -24,6 +24,7 @@ module Himari
     # - require_pkce [Boolean] force PKCE for metadata clients (default true; they are public).
     # - ignore_localhost_redirect_uri_port [Boolean] relax the port of loopback redirect_uris when
     #   matching at the authorization endpoint (default true; see RFC 8252 §7.3).
+    # - skip_consent [Boolean] let metadata clients bypass the consent page (default false).
     # - ssrf [true, false, Hash] SSRF filtering. true (default) restricts to https; a Hash is
     #   merged into the ssrf_filter plugin options (e.g. allowed_schemes); false disables it
     #   (only for an authorization server running on a loopback address).
@@ -41,7 +42,7 @@ module Himari
       # would let a slow sender hold the fetch open indefinitely.
       DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10, read_timeout: 10}.freeze
 
-      Options = Data.define(:allowed_client_ids, :require_pkce, :ignore_localhost_redirect_uri_port, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
+      Options = Data.define(:allowed_client_ids, :require_pkce, :ignore_localhost_redirect_uri_port, :skip_consent, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
 
       def initialize(app, kwargs = {})
         @app = app
@@ -49,6 +50,7 @@ module Himari
           allowed_client_ids: kwargs.fetch(:allowed_client_ids, []),
           require_pkce: kwargs.fetch(:require_pkce, true),
           ignore_localhost_redirect_uri_port: kwargs.fetch(:ignore_localhost_redirect_uri_port, true),
+          skip_consent: kwargs.fetch(:skip_consent, false),
           ssrf: kwargs.fetch(:ssrf, true),
           user_agent: kwargs.fetch(:user_agent, DEFAULT_USER_AGENT),
           http_timeout: kwargs.fetch(:http_timeout, DEFAULT_HTTP_TIMEOUT),
@@ -63,6 +65,7 @@ module Himari
           allowed_client_ids: @options.allowed_client_ids,
           require_pkce: @options.require_pkce,
           ignore_localhost_redirect_uri_port: @options.ignore_localhost_redirect_uri_port,
+          skip_consent: @options.skip_consent,
           max_response_size: @options.max_response_size,
           cache_min_ttl: @options.cache_min_ttl,
           cache_max_ttl: @options.cache_max_ttl,

--- a/himari/lib/himari/services/oidc_authorization_endpoint.rb
+++ b/himari/lib/himari/services/oidc_authorization_endpoint.rb
@@ -9,16 +9,30 @@ module Himari
     class OidcAuthorizationEndpoint
       class ReauthenticationRequired < StandardError; end
 
+      # Raised when the user must be shown the consent page before a code is granted. Carries the
+      # data the page renders (the requesting client and the requested scopes); app.rb rescues it.
+      class ConsentRequired < StandardError
+        def initialize(client:, scopes:)
+          @client = client
+          @scopes = scopes
+          super('consent required')
+        end
+
+        attr_reader :client, :scopes
+      end
+
       SUPPORTED_RESPONSE_TYPES = ['code'] # TODO: share with oidc metadata
 
       # @param authz [Himari::AuthorizationCode] pending (unpersisted) authz data
       # @param client [Himari::ClientRegistration]
       # @param storage [Himari::Storages::Base]
+      # @param consent [:approve, :deny, nil] the user's consent decision (nil = not yet asked)
       # @param logger [Logger]
-      def initialize(authz:, client:, storage:, logger: nil)
+      def initialize(authz:, client:, storage:, consent: nil, logger: nil)
         @authz = authz
         @client = client
         @storage = storage
+        @consent = consent
         @logger = logger
       end
 
@@ -58,6 +72,23 @@ module Himari
           req.bad_request!(:request_uri_not_supported, "Request Object is not implemented") if req.request_uri || req.request
           req.bad_request!(:invalid_request, 'prompt=none should not contain any other value') if req.prompt.include?('none') && req.prompt.any? { |x| x != 'none' }
           raise ReauthenticationRequired if req.prompt.include?('login') || req.prompt.include?('select_account')
+
+          # Consent gate. Clients granted skip_consent (the default for dynamically/metadata-
+          # registered clients) bypass it; prompt=consent forces the page regardless.
+          if !@client.skip_consent || req.prompt.include?('consent')
+            case @consent
+            when :approve
+              # consent given; fall through and grant
+            when :deny
+              next req.access_denied!
+            else
+              # prompt=none forbids interaction (OIDC §3.1.2.1), so surface the error via redirect
+              # instead of rendering the page.
+              next req.consent_required! if req.prompt.include?('none')
+
+              raise ConsentRequired.new(client: @client, scopes: req.scope)
+            end
+          end
 
           requested_response_types = [*req.response_type]
           unless SUPPORTED_RESPONSE_TYPES.include?(requested_response_types.map(&:to_s).join(' '))

--- a/himari/public/public/index.css
+++ b/himari/public/public/index.css
@@ -60,6 +60,24 @@ main > header img, main > footer img {
   margin-top: 30px;
 }
 
+.consent-detail {
+  margin: 12px 0 24px;
+}
+.consent-scopes {
+  display: inline-block;
+  text-align: left;
+}
+.himari-consent .actions form {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+}
+.consent-deny {
+  border-color: #4E6994 !important;
+  background: transparent !important;
+  color: #4E6994 !important;
+}
+
 .notice {
   background-color: white;
   border: 1px #bfa88a solid;

--- a/himari/spec/himari/app_authorize_prompt_spec.rb
+++ b/himari/spec/himari/app_authorize_prompt_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/builder'
+require 'rack/session/cookie'
+require 'addressable'
+require 'himari'
+require 'himari/middlewares/config'
+require 'himari/middlewares/client'
+require 'himari/storages/memory'
+
+RSpec.describe 'App /oidc/authorize prompt propagation through login' do
+  include Rack::Test::Methods
+
+  let(:storage) { Himari::Storages::Memory.new }
+
+  let(:app) do
+    s = storage
+    Rack::Builder.new do
+      use Rack::Session::Cookie, secret: 'a' * 64
+      use Himari::Middlewares::Config, issuer: 'https://test.invalid', storage: s, providers: [{name: :developer}], log_level: Logger::FATAL
+      use Himari::Middlewares::Client, id: 'cid', name: 'client1', redirect_uris: %w(https://rp.invalid/cb), confidential: false
+      run Himari::App
+    end
+  end
+
+  # The login page renders a per-provider form whose action carries a back_to URL pointing at the
+  # original authorize request; pull the prompt out of that nested URL.
+  def back_to_prompt
+    action = last_response.body[%r{action="(/auth/developer[^"]*)"}, 1]
+    back_to = Addressable::URI.parse(action).query_values.fetch('back_to')
+    Addressable::URI.parse(back_to).query_values['prompt']
+  end
+
+  def authorize(prompt)
+    get "/oidc/authorize?client_id=cid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&prompt=#{prompt}"
+    expect(last_response.status).to eq(200)
+  end
+
+  it "preserves prompt=consent so it still applies after login" do
+    authorize('consent')
+    expect(back_to_prompt).to eq('consent')
+  end
+
+  it "drops prompt=login to avoid re-triggering the login screen in a loop" do
+    authorize('login')
+    expect(back_to_prompt).to be_nil
+  end
+
+  it "drops prompt=select_account too" do
+    authorize('select_account')
+    expect(back_to_prompt).to be_nil
+  end
+
+  it "keeps only consent when login and consent are combined" do
+    authorize('login+consent')
+    expect(back_to_prompt).to eq('consent')
+  end
+end

--- a/himari/spec/himari/client_registration_spec.rb
+++ b/himari/spec/himari/client_registration_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Himari::ClientRegistration do
     end
   end
 
+  describe "#skip_consent" do
+    it "defaults to false" do
+      expect(described_class.new(id: 'a', redirect_uris: [], confidential: false).skip_consent).to eq(false)
+    end
+
+    it "is settable to true" do
+      expect(described_class.new(id: 'a', redirect_uris: [], confidential: false, skip_consent: true).skip_consent).to eq(true)
+    end
+  end
+
   describe "confidential validation" do
     it "requires a secret for confidential clients" do
       expect { described_class.new(id: 'a', redirect_uris: []) }.to raise_error(ArgumentError)

--- a/himari/spec/himari/dynamic_client_registration_spec.rb
+++ b/himari/spec/himari/dynamic_client_registration_spec.rb
@@ -24,8 +24,12 @@ RSpec.describe Himari::DynamicClientRegistration do
         expect(client.response_types).to eq(%w(code))
       end
 
-      it "skips consent on the converted ClientRegistration" do
-        expect(client.to_client_registration.skip_consent).to eq(true)
+      it "does not skip consent on the converted ClientRegistration by default" do
+        expect(client.to_client_registration.skip_consent).to eq(false)
+      end
+
+      it "skips consent when the provider opts in" do
+        expect(client.to_client_registration(skip_consent: true).skip_consent).to eq(true)
       end
 
       it "omits client_secret from the registration response" do

--- a/himari/spec/himari/dynamic_client_registration_spec.rb
+++ b/himari/spec/himari/dynamic_client_registration_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Himari::DynamicClientRegistration do
         expect(client.response_types).to eq(%w(code))
       end
 
+      it "skips consent on the converted ClientRegistration" do
+        expect(client.to_client_registration.skip_consent).to eq(true)
+      end
+
       it "omits client_secret from the registration response" do
         expect(client.registration_response).not_to have_key(:client_secret)
       end

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         expect(client.match_hint?(id: url)).to eq(true)
       end
 
+      it 'skips consent for metadata clients' do
+        expect(provider.collect(id: url).first.skip_consent).to eq(true)
+      end
+
       it 'enables ignore_localhost_redirect_uri_port by default' do
         expect(provider.collect(id: url).first.ignore_localhost_redirect_uri_port).to eq(true)
       end

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -56,8 +56,16 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         expect(client.match_hint?(id: url)).to eq(true)
       end
 
-      it 'skips consent for metadata clients' do
-        expect(provider.collect(id: url).first.skip_consent).to eq(true)
+      it 'does not skip consent for metadata clients by default' do
+        expect(provider.collect(id: url).first.skip_consent).to eq(false)
+      end
+
+      context 'with skip_consent enabled' do
+        let(:options) { {skip_consent: true} }
+
+        it 'lets the metadata client bypass consent' do
+          expect(provider.collect(id: url).first.skip_consent).to eq(true)
+        end
       end
 
       it 'enables ignore_localhost_redirect_uri_port by default' do

--- a/himari/spec/himari/item_providers/storage_spec.rb
+++ b/himari/spec/himari/item_providers/storage_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Himari::ItemProviders::Storage do
     collected = provider.collect(id: client.id)
     expect(collected.map(&:id)).to eq([client.id])
     expect(collected.first).to be_a(Himari::ClientRegistration)
+    expect(collected.first.skip_consent).to eq(false)
+  end
+
+  context "with skip_consent enabled" do
+    subject(:provider) { described_class.new(storage: storage, skip_consent: true) }
+
+    it "applies skip_consent to resolved clients" do
+      expect(provider.collect(id: client.id).first.skip_consent).to eq(true)
+    end
   end
 
   it "returns nothing without an id hint" do

--- a/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
 
   let(:authz) { Himari::AuthorizationCode.make(client_id: 'clientid', claims: {sub: 'chihiro'}) }
   let(:require_pkce) { false }
+  let(:skip_consent) { true }
+  let(:consent) { nil }
   let(:redirect_uris) { ['https://rp.invalid/cb'] }
-  let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:) }
+  let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, skip_consent:) }
   let(:storage) { Himari::Storages::Memory.new }
   let(:logger) { Rack::NullLogger.new(nil) }
 
-  let(:app) { described_class.new(authz: authz, client: client, storage: storage, logger: logger) }
+  let(:app) { described_class.new(authz: authz, client: client, storage: storage, consent: consent, logger: logger) }
 
   context "with invalid clientid combination" do
     it "returns 400" do
@@ -168,6 +170,73 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
     end
   end
 
+  context "when consent is required (skip_consent=false)" do
+    let(:skip_consent) { false }
+
+    context "with no consent decision yet" do
+      it "raises ConsentRequired carrying the client and scopes" do
+        expect do
+          get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid+profile&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
+        end.to raise_error(Himari::Services::OidcAuthorizationEndpoint::ConsentRequired) do |e|
+          expect(e.client).to eq(client)
+          expect(e.scopes).to contain_exactly('openid', 'profile')
+        end
+      end
+    end
+
+    context "when consent is approved" do
+      let(:consent) { :approve }
+
+      it "returns a grant code" do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
+        expect(last_response.status).to eq(302)
+        query = Addressable::URI.parse(last_response.headers['location']).query_values
+        expect(query['code']).to be_a(String)
+        expect(storage.find_authorization(query['code'])).to be_a(Himari::AuthorizationCode)
+      end
+    end
+
+    context "when consent is denied" do
+      let(:consent) { :deny }
+
+      it "redirects with error=access_denied" do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
+        expect(last_response.status).to eq(302)
+        query = Addressable::URI.parse(last_response.headers['location']).query_values
+        expect(query['error']).to eq('access_denied')
+        expect(query['state']).to eq('x')
+      end
+    end
+
+    context "with prompt=none" do
+      it "redirects with error=consent_required instead of prompting" do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn&prompt=none'
+        expect(last_response.status).to eq(302)
+        query = Addressable::URI.parse(last_response.headers['location']).query_values
+        expect(query['error']).to eq('consent_required')
+      end
+    end
+  end
+
+  context "when skip_consent=true but prompt=consent forces the page" do
+    it "raises ConsentRequired" do
+      expect do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn&prompt=consent'
+      end.to raise_error(Himari::Services::OidcAuthorizationEndpoint::ConsentRequired)
+    end
+
+    context "when forced consent is approved" do
+      let(:consent) { :approve }
+
+      it "returns a grant code" do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn&prompt=consent'
+        expect(last_response.status).to eq(302)
+        query = Addressable::URI.parse(last_response.headers['location']).query_values
+        expect(query['code']).to be_a(String)
+      end
+    end
+  end
+
   context "with a mismatched redirect_uri" do
     it "returns invalid_request without redirecting" do
       get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=https%3A%2F%2Fattacker.invalid%2Fcb&nonce=nn'
@@ -187,7 +256,7 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
     end
 
     context "when ignore_localhost_redirect_uri_port is disabled" do
-      let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, ignore_localhost_redirect_uri_port: false) }
+      let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, skip_consent:, ignore_localhost_redirect_uri_port: false) }
 
       it "rejects a differing port" do
         get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid&state=x&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcb&nonce=nn'

--- a/himari/views/consent.erb
+++ b/himari/views/consent.erb
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title><%= h(msg(:consent_page_title, nil) || msg(:consent_title, "Authorize access")) %></title>
+    <link rel="stylesheet" href="/public/index.css?cb=<%= cachebuster %>" type="text/css" />
+    <meta name="viewport" content="initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+
+    <meta name="himari:release" content="<%= release_code %>">
+  </head>
+
+  <body class='himari-app himari-consent'>
+    <main>
+
+      <header>
+        <h1><%= msg(:consent_title, "Authorize access") %></h1>
+        <%= msg(:consent_header) %>
+
+        <% if @notice %>
+          <div class='notice'>
+            <p><%=h @notice %></p>
+          </div>
+        <% end %>
+      </header>
+
+      <section class='consent-detail'>
+        <p><strong><%=h(@consent_client.name || @consent_client.id) %></strong> <%= msg(:consent_request_message, "is requesting access to your account.") %></p>
+
+        <% if @consent_scopes.any? %>
+          <p><%= msg(:consent_scopes_message, "The following will be shared:") %></p>
+          <ul class='consent-scopes'>
+            <% @consent_scopes.each do |scope| %>
+              <li><%=h msg(:"scope_#{scope}", scope) %></li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p><%= msg(:consent_no_scopes_message, "Basic sign-in information will be shared.") %></p>
+        <% end %>
+      </section>
+
+      <nav class='actions'>
+        <form action="<%=h request.path %>" method="POST" id='consent-form'>
+          <input type="hidden" name="<%= csrf_token_name %>" value="<%= csrf_token_value %>" />
+          <% request.GET.each do |k, v| %>
+            <% next if k == csrf_token_name || k == '_consent' %>
+            <input type="hidden" name="<%=h k %>" value="<%=h v %>" />
+          <% end %>
+          <button type='submit' name='_consent' value='approve' class='consent-approve'><%= msg(:consent_approve, "Approve") %></button>
+          <button type='submit' name='_consent' value='deny' class='consent-deny'><%= msg(:consent_deny, "Deny") %></button>
+        </form>
+      </nav>
+
+      <footer>
+        <%= msg(:consent_footer) %>
+      </footer>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Add an interactive consent page to /oidc/authorize that shows the requesting client name and the requested scopes before a code is granted. Until now authorization was granted silently once the downstream rules passed.

## authorize: consent page gated by skip_consent

- ClientRegistration gains skip_consent (default false). The page is shown unless the client skips it; prompt=consent forces it even when skipped. There is no remembered grant — the gate is purely the flag plus prompt.
- The decision flows through OidcAuthorizationEndpoint: it raises ConsentRequired (rendered by app.rb, mirroring ReauthenticationRequired) when interaction is needed, maps approve/deny to grant/access_denied, and answers prompt=none with consent_required instead of prompting. /oidc/authorize now also accepts POST for the consent form, which re-submits the original params plus the CSRF token.
- known_providers no longer drops the whole prompt parameter from the post-login back_to; it strips only login/select_account (which would loop the login screen) and keeps the rest, so prompt=consent survives authentication.
- dev/ uses a single skip_consent client with a prompt=consent button so both paths are exercisable.

## consent: default skip_consent off for dynamic & metadata clients

Dynamic (RFC 7591) and metadata-document clients are treated the same as static ones: they show the consent page by default. Skipping is an opt-in operator choice rather than a property of how the client registered.

- DynamicClients and MetadataClients middlewares learn a skip_consent option (default false), threaded to the client provider so it applies to every client they resolve.
- to_client_registration and the providers carry the flag through; prompt=consent still forces the page regardless.