### PR TITLE
ClientRegistration: gains scopes allow-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ use(Himari::Middlewares::Client,
 
       # skip_consent: false # requires consent. default to true
 
+  # scopes: %w(openid offline_access), # (default) recognised scopes. Requested scopes outside
+  #   this list are dropped before consent/grant; openid and offline_access are always recognised.
+
   # Entries are matched by simple string comparison. A Regexp entry is matched
   # with #match? against the request redirect_uri instead, e.g.
   #   redirect_uris: [%r{\Ahttps://app\.example\.net/oauth2/[^/]+\z}]
@@ -157,7 +160,7 @@ Himari acts as an OIDC OpenID Provider. OIDC discovery metadata served at `/.wel
 
 ## Caveats
 
-- Recognizes `openid` scope only.
+- Acts on the `openid` and `offline_access` scopes; any other requested scope is recognised only when listed in a client's `scopes`, and otherwise dropped from the request.
 - Implements Authorization Code Grant Flow and [Refresh Token Grant Flow](./docs/refresh-tokens.md) only. Public clients should use the same flow with PKCE.
 
 ## Development

--- a/himari/lib/himari/client_registration.rb
+++ b/himari/lib/himari/client_registration.rb
@@ -9,7 +9,11 @@ module Himari
     # draft-ietf-oauth-v2-1-15 §8.4.2). Addressable returns IPv6 hosts bracketed.
     LOOPBACK_HOSTS = %w[127.0.0.1 [::1] localhost].freeze
 
-    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true, ignore_localhost_redirect_uri_port: true, skip_consent: false)
+    # Scopes Himari itself acts on; recognised for every client regardless of the configured
+    # scopes list, so a client need not enumerate them to use OIDC or obtain a refresh token.
+    IMPLICIT_SCOPES = %w[openid offline_access].freeze
+
+    def initialize(id:, redirect_uris:, name: nil, secret: nil, secret_hash: nil, preferred_key_group: nil, require_pkce: false, confidential: true, ignore_localhost_redirect_uri_port: true, skip_consent: false, scopes: IMPLICIT_SCOPES)
       @name = name
       @id = id
       @secret = secret
@@ -20,12 +24,13 @@ module Himari
       @confidential = confidential
       @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
       @skip_consent = skip_consent
+      @scopes = (Array(scopes) | IMPLICIT_SCOPES).freeze
 
       raise ArgumentError, "name starts with '_' is reserved" if @name&.start_with?('_')
       raise ArgumentError, "either secret or secret_hash must be present" if confidential && !@secret && !@secret_hash
     end
 
-    attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce, :ignore_localhost_redirect_uri_port, :skip_consent
+    attr_reader :name, :id, :redirect_uris, :preferred_key_group, :require_pkce, :ignore_localhost_redirect_uri_port, :skip_consent, :scopes
 
     def confidential?
       @confidential
@@ -57,8 +62,15 @@ module Himari
       redirect_uris.any? { |registered| redirect_uri_match?(registered, given) }
     end
 
+    # Drop requested scopes this client does not recognise. OAuth servers are expected to ignore
+    # unknown scopes rather than reject the request (draft-ietf-oauth-v2-1 §3.2.2.1); request
+    # order is preserved.
+    def filter_scopes(requested)
+      Array(requested).select { |scope| scopes.include?(scope) }
+    end
+
     def as_log
-      {name: name, id: id, skip_consent: skip_consent}
+      {name: name, id: id, skip_consent: skip_consent, scopes: scopes}
     end
 
     def match_hint?(id: nil)

--- a/himari/lib/himari/dynamic_client_registration.rb
+++ b/himari/lib/himari/dynamic_client_registration.rb
@@ -175,9 +175,9 @@ module Himari
 
     # The client object the OIDC authorization/token endpoints consume. Dynamic records carry
     # no name (so operator rules keyed on name never match them) and pass through the secret
-    # hash only for confidential clients. skip_consent defaults to false and is supplied by the
-    # provider from the DynamicClients middleware option.
-    def to_client_registration(skip_consent: false)
+    # hash only for confidential clients. skip_consent and scopes default to the conservative
+    # values and are supplied by the provider from the DynamicClients middleware options.
+    def to_client_registration(skip_consent: false, scopes: ClientRegistration::IMPLICIT_SCOPES)
       ClientRegistration.new(
         id: id,
         redirect_uris: redirect_uris,
@@ -187,6 +187,7 @@ module Himari
         confidential: confidential?,
         ignore_localhost_redirect_uri_port: ignore_localhost_redirect_uri_port,
         skip_consent: skip_consent,
+        scopes: scopes,
       )
     end
 

--- a/himari/lib/himari/item_providers/oauth_client_metadata.rb
+++ b/himari/lib/himari/item_providers/oauth_client_metadata.rb
@@ -34,7 +34,7 @@ module Himari
       # @param session [HTTPX::Session] persistent, SSRF-filtered session (built by the middleware)
       # @param allowed_client_ids [Array<String, Regexp>] empty = allow any compliant https URL
       def initialize(session:, allowed_client_ids: [], require_pkce: true, ignore_localhost_redirect_uri_port: true,
-        skip_consent: false,
+        skip_consent: false, scopes: Himari::ClientRegistration::IMPLICIT_SCOPES,
         max_response_size: 5120,
         cache_min_ttl: 60, cache_max_ttl: 86400, cache_default_ttl: 300, cache_max_total_size: 1_048_576, logger: nil)
         @session = session
@@ -42,6 +42,7 @@ module Himari
         @require_pkce = require_pkce
         @ignore_localhost_redirect_uri_port = ignore_localhost_redirect_uri_port
         @skip_consent = skip_consent
+        @scopes = scopes
         @max_response_size = max_response_size
         @cache_min_ttl = cache_min_ttl
         @cache_max_ttl = cache_max_ttl
@@ -153,6 +154,7 @@ module Himari
           require_pkce: @require_pkce,
           ignore_localhost_redirect_uri_port: @ignore_localhost_redirect_uri_port,
           skip_consent: @skip_consent,
+          scopes: @scopes,
         )
       end
 

--- a/himari/lib/himari/item_providers/storage.rb
+++ b/himari/lib/himari/item_providers/storage.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'himari/item_provider'
+require 'himari/client_registration'
 
 module Himari
   module ItemProviders
@@ -14,16 +15,18 @@ module Himari
 
       # @param storage [Himari::Storages::Base]
       # @param skip_consent [Boolean] applied to every dynamic client this provider resolves
-      def initialize(storage:, skip_consent: false)
+      # @param scopes [Array<String>] recognised scopes applied to every dynamic client resolved
+      def initialize(storage:, skip_consent: false, scopes: Himari::ClientRegistration::IMPLICIT_SCOPES)
         @storage = storage
         @skip_consent = skip_consent
+        @scopes = scopes
       end
 
       def collect(id: nil, **_hint)
         return [] unless id
 
         client = @storage.find_dynamic_client(id)
-        client&.active? ? [client.to_client_registration(skip_consent: @skip_consent)] : []
+        client&.active? ? [client.to_client_registration(skip_consent: @skip_consent, scopes: @scopes)] : []
       end
     end
   end

--- a/himari/lib/himari/middlewares/dynamic_clients.rb
+++ b/himari/lib/himari/middlewares/dynamic_clients.rb
@@ -17,18 +17,21 @@ module Himari
     class DynamicClients
       RACK_KEY = 'himari.dynamic_clients'
 
-      Options = Data.define(:registration_lifetime, :ignore_localhost_redirect_uri_port, :skip_consent, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
+      Options = Data.define(:registration_lifetime, :ignore_localhost_redirect_uri_port, :skip_consent, :scopes, :grant_types_supported, :response_types_supported, :token_endpoint_auth_methods_supported)
 
       # @param registration_lifetime [Integer] seconds a registration stays valid (default 180 days)
       # @param ignore_localhost_redirect_uri_port [Boolean] relax the port of loopback redirect_uris
       #   for registered clients (default true; see RFC 8252 §7.3)
       # @param skip_consent [Boolean] let registered clients bypass the consent page (default false)
+      # @param scopes [Array<String>] recognised scopes inherited by registered clients; scopes
+      #   outside this list are dropped from authorization requests (default openid, offline_access)
       def initialize(app, kwargs = {})
         @app = app
         @options = Options.new(
           registration_lifetime: kwargs.fetch(:registration_lifetime) { Himari::DynamicClientRegistration::REGISTRATION_LIFETIME },
           ignore_localhost_redirect_uri_port: kwargs.fetch(:ignore_localhost_redirect_uri_port, true),
           skip_consent: kwargs.fetch(:skip_consent, false),
+          scopes: kwargs.fetch(:scopes, Himari::ClientRegistration::IMPLICIT_SCOPES),
           grant_types_supported: Himari::DynamicClientRegistration::SUPPORTED_GRANT_TYPES,
           response_types_supported: Himari::DynamicClientRegistration::SUPPORTED_RESPONSE_TYPES,
           token_endpoint_auth_methods_supported: Himari::DynamicClientRegistration::SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS,
@@ -43,7 +46,7 @@ module Himari
 
         env[RACK_KEY] = @options
         env[Himari::Middlewares::Client::RACK_KEY] ||= []
-        env[Himari::Middlewares::Client::RACK_KEY] += [Himari::ItemProviders::Storage.new(storage: config.storage, skip_consent: @options.skip_consent)]
+        env[Himari::Middlewares::Client::RACK_KEY] += [Himari::ItemProviders::Storage.new(storage: config.storage, skip_consent: @options.skip_consent, scopes: @options.scopes)]
 
         @app.call(env)
       end

--- a/himari/lib/himari/middlewares/metadata_clients.rb
+++ b/himari/lib/himari/middlewares/metadata_clients.rb
@@ -25,6 +25,8 @@ module Himari
     # - ignore_localhost_redirect_uri_port [Boolean] relax the port of loopback redirect_uris when
     #   matching at the authorization endpoint (default true; see RFC 8252 §7.3).
     # - skip_consent [Boolean] let metadata clients bypass the consent page (default false).
+    # - scopes [Array<String>] recognised scopes inherited by metadata clients; scopes outside
+    #   this list are dropped from authorization requests (default openid, offline_access).
     # - ssrf [true, false, Hash] SSRF filtering. true (default) restricts to https; a Hash is
     #   merged into the ssrf_filter plugin options (e.g. allowed_schemes); false disables it
     #   (only for an authorization server running on a loopback address).
@@ -42,7 +44,7 @@ module Himari
       # would let a slow sender hold the fetch open indefinitely.
       DEFAULT_HTTP_TIMEOUT = {connect_timeout: 5, request_timeout: 10, read_timeout: 10}.freeze
 
-      Options = Data.define(:allowed_client_ids, :require_pkce, :ignore_localhost_redirect_uri_port, :skip_consent, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
+      Options = Data.define(:allowed_client_ids, :require_pkce, :ignore_localhost_redirect_uri_port, :skip_consent, :scopes, :ssrf, :user_agent, :http_timeout, :max_response_size, :cache_min_ttl, :cache_max_ttl, :cache_default_ttl, :cache_max_total_size)
 
       def initialize(app, kwargs = {})
         @app = app
@@ -51,6 +53,7 @@ module Himari
           require_pkce: kwargs.fetch(:require_pkce, true),
           ignore_localhost_redirect_uri_port: kwargs.fetch(:ignore_localhost_redirect_uri_port, true),
           skip_consent: kwargs.fetch(:skip_consent, false),
+          scopes: kwargs.fetch(:scopes, Himari::ClientRegistration::IMPLICIT_SCOPES),
           ssrf: kwargs.fetch(:ssrf, true),
           user_agent: kwargs.fetch(:user_agent, DEFAULT_USER_AGENT),
           http_timeout: kwargs.fetch(:http_timeout, DEFAULT_HTTP_TIMEOUT),
@@ -66,6 +69,7 @@ module Himari
           require_pkce: @options.require_pkce,
           ignore_localhost_redirect_uri_port: @options.ignore_localhost_redirect_uri_port,
           skip_consent: @options.skip_consent,
+          scopes: @options.scopes,
           max_response_size: @options.max_response_size,
           cache_min_ttl: @options.cache_min_ttl,
           cache_max_ttl: @options.cache_max_ttl,

--- a/himari/lib/himari/services/oidc_authorization_endpoint.rb
+++ b/himari/lib/himari/services/oidc_authorization_endpoint.rb
@@ -73,6 +73,9 @@ module Himari
           req.bad_request!(:invalid_request, 'prompt=none should not contain any other value') if req.prompt.include?('none') && req.prompt.any? { |x| x != 'none' }
           raise ReauthenticationRequired if req.prompt.include?('login') || req.prompt.include?('select_account')
 
+          # Drop scopes this client does not recognise before they reach consent or the grant.
+          scopes = @client.filter_scopes(req.scope)
+
           # Consent gate. Clients granted skip_consent (the default for dynamically/metadata-
           # registered clients) bypass it; prompt=consent forces the page regardless.
           if !@client.skip_consent || req.prompt.include?('consent')
@@ -86,7 +89,7 @@ module Himari
               # instead of rendering the page.
               next req.consent_required! if req.prompt.include?('none')
 
-              raise ConsentRequired.new(client: @client, scopes: req.scope)
+              raise ConsentRequired.new(client: @client, scopes: scopes)
             end
           end
 
@@ -99,8 +102,8 @@ module Himari
             @authz.redirect_uri = res.redirect_uri
             @authz.nonce = req.nonce
 
-            @authz.openid = req.scope.include?('openid')
-            @authz.offline_access = req.scope.include?('offline_access')
+            @authz.openid = scopes.include?('openid')
+            @authz.offline_access = scopes.include?('offline_access')
             if req.code_challenge && req.code_challenge_method
               @authz.code_challenge = req.code_challenge
               @authz.code_challenge_method = req.code_challenge_method || 'plain'

--- a/himari/spec/himari/client_registration_spec.rb
+++ b/himari/spec/himari/client_registration_spec.rb
@@ -45,6 +45,34 @@ RSpec.describe Himari::ClientRegistration do
     end
   end
 
+  describe "#scopes" do
+    it "defaults to the implicit scopes" do
+      expect(described_class.new(id: 'a', redirect_uris: [], confidential: false).scopes).to contain_exactly('openid', 'offline_access')
+    end
+
+    it "unions configured scopes with the implicit ones" do
+      client = described_class.new(id: 'a', redirect_uris: [], confidential: false, scopes: %w(profile openid))
+      expect(client.scopes).to contain_exactly('openid', 'offline_access', 'profile')
+    end
+  end
+
+  describe "#filter_scopes" do
+    let(:client) { described_class.new(id: 'a', redirect_uris: [], confidential: false, scopes: %w(profile)) }
+
+    it "drops unrecognised scopes while preserving request order" do
+      expect(client.filter_scopes(%w(email profile openid))).to eq(%w(profile openid))
+    end
+
+    it "always recognises the implicit scopes" do
+      client = described_class.new(id: 'a', redirect_uris: [], confidential: false, scopes: %w(profile))
+      expect(client.filter_scopes(%w(openid offline_access))).to eq(%w(openid offline_access))
+    end
+
+    it "handles nil" do
+      expect(client.filter_scopes(nil)).to eq([])
+    end
+  end
+
   describe "confidential validation" do
     it "requires a secret for confidential clients" do
       expect { described_class.new(id: 'a', redirect_uris: []) }.to raise_error(ArgumentError)

--- a/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
+++ b/himari/spec/himari/item_providers/oauth_client_metadata_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe Himari::ItemProviders::OauthClientMetadata do
         end
       end
 
+      it 'defaults to the implicit scopes' do
+        expect(provider.collect(id: url).first.scopes).to contain_exactly('openid', 'offline_access')
+      end
+
+      context 'with scopes configured' do
+        let(:options) { {scopes: %w(profile)} }
+
+        it 'inherits the configured scopes onto the registration' do
+          expect(provider.collect(id: url).first.scopes).to contain_exactly('openid', 'offline_access', 'profile')
+        end
+      end
+
       it 'enables ignore_localhost_redirect_uri_port by default' do
         expect(provider.collect(id: url).first.ignore_localhost_redirect_uri_port).to eq(true)
       end

--- a/himari/spec/himari/item_providers/storage_spec.rb
+++ b/himari/spec/himari/item_providers/storage_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Himari::ItemProviders::Storage do
     end
   end
 
+  it "defaults resolved clients to the implicit scopes" do
+    expect(provider.collect(id: client.id).first.scopes).to contain_exactly('openid', 'offline_access')
+  end
+
+  context "with scopes configured" do
+    subject(:provider) { described_class.new(storage: storage, scopes: %w(profile)) }
+
+    it "applies the configured scopes to resolved clients" do
+      expect(provider.collect(id: client.id).first.scopes).to contain_exactly('openid', 'offline_access', 'profile')
+    end
+  end
+
   it "returns nothing without an id hint" do
     expect(provider.collect).to eq([])
   end

--- a/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
@@ -174,12 +174,24 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
     let(:skip_consent) { false }
 
     context "with no consent decision yet" do
-      it "raises ConsentRequired carrying the client and scopes" do
+      it "raises ConsentRequired carrying the client and recognised scopes only" do
         expect do
           get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid+profile&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
         end.to raise_error(Himari::Services::OidcAuthorizationEndpoint::ConsentRequired) do |e|
           expect(e.client).to eq(client)
-          expect(e.scopes).to contain_exactly('openid', 'profile')
+          expect(e.scopes).to contain_exactly('openid')
+        end
+      end
+
+      context "when the client declares the requested scope" do
+        let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, skip_consent:, scopes: %w(profile)) }
+
+        it "keeps the declared scope alongside the implicit ones" do
+          expect do
+            get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid+profile&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
+          end.to raise_error(Himari::Services::OidcAuthorizationEndpoint::ConsentRequired) do |e|
+            expect(e.scopes).to contain_exactly('openid', 'profile')
+          end
         end
       end
     end


### PR DESCRIPTION
Requested scopes outside a client's recognised set are dropped before they reach the consent page or the grant, so a client cannot obtain or display scopes it was not configured for. openid and offline_access are always implicitly recognised; the per-client list only adds to those.

The DynamicClients and MetadataClients middlewares take a scopes option that is inherited by the client registrations they source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)