### PR TITLE
lambda/image: copy image with skopeo, support aws provider v6

### DIFF
--- a/himari-aws/lambda/terraform/README.md
+++ b/himari-aws/lambda/terraform/README.md
@@ -36,10 +36,13 @@ module "himari_image" {
 
   repository_name  = "himari-lambda"
   source_image_tag = "" # Replace with image tag
+  architecture     = "x86_64" # or arm64; must match the Lambda architecture
 }
 ```
 
-- Uses null_resource with `docker` command to perform pull, retag and push to ECR private locally
+- Uses null_resource with `skopeo` command to copy the image to ECR private locally (requires `skopeo` on the machine running Terraform)
+- `architecture` selects which platform to copy out of the multi-arch source image (defaults to `x86_64`); set it to match the `architecture` you pass to the functions module
+- Requires Terraform >= 1.10 and AWS provider >= 5.83 (ephemeral resource for ECR credentials)
 - Prebuilt image tag is based on git commit SHA: https://github.com/sorah/himari/commits/main
 
 ## functions

--- a/himari-aws/lambda/terraform/iam/outputs.tf
+++ b/himari-aws/lambda/terraform/iam/outputs.tf
@@ -1,3 +1,7 @@
 output "role_arn" {
   value = aws_iam_role.role.arn
 }
+
+output "role_name" {
+  value = aws_iam_role.role.name
+}

--- a/himari-aws/lambda/terraform/iam/variables.tf
+++ b/himari-aws/lambda/terraform/iam/variables.tf
@@ -40,5 +40,5 @@ variable "secrets_rotation_function_arn" {
 }
 
 locals {
-  dynamodb_table_arn = coalesce(var.dynamodb_table_arn, var.dynamodb_table_name != null ? "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}" : null)
+  dynamodb_table_arn = coalesce(var.dynamodb_table_arn, var.dynamodb_table_name != null ? "arn:aws:dynamodb:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodb_table_name}" : null)
 }

--- a/himari-aws/lambda/terraform/iam/versions.tf
+++ b/himari-aws/lambda/terraform/iam/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
     }
   }
 }

--- a/himari-aws/lambda/terraform/image/copy.sh
+++ b/himari-aws/lambda/terraform/image/copy.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -xe
-aws ecr get-login-password | docker login --username AWS --password-stdin "${REPOSITORY_URL}"
-docker pull "public.ecr.aws/sorah/himari-lambda:${SOURCE_IMAGE_TAG}"
-docker tag "public.ecr.aws/sorah/himari-lambda:${SOURCE_IMAGE_TAG}" "${REPOSITORY_URL}:${SOURCE_IMAGE_TAG}"
-docker push "${REPOSITORY_URL}:${SOURCE_IMAGE_TAG}"

--- a/himari-aws/lambda/terraform/image/copy.tf
+++ b/himari-aws/lambda/terraform/image/copy.tf
@@ -1,6 +1,4 @@
-ephemeral "aws_ecr_authorization_token" "repo" {
-  registry_id = aws_ecr_repository.repo.registry_id
-}
+ephemeral "aws_ecr_authorization_token" "repo" {}
 
 locals {
   # Map Lambda's architecture notation to the source image's OS/arch so skopeo

--- a/himari-aws/lambda/terraform/image/copy.tf
+++ b/himari-aws/lambda/terraform/image/copy.tf
@@ -12,7 +12,7 @@ locals {
 
 resource "null_resource" "copy-image" {
   triggers = {
-    region           = data.aws_region.current.name
+    region           = data.aws_region.current.region
     repository_url   = aws_ecr_repository.repo.repository_url
     source_image_tag = var.source_image_tag
     architecture     = var.architecture

--- a/himari-aws/lambda/terraform/image/copy.tf
+++ b/himari-aws/lambda/terraform/image/copy.tf
@@ -2,11 +2,22 @@ ephemeral "aws_ecr_authorization_token" "repo" {
   registry_id = aws_ecr_repository.repo.registry_id
 }
 
+locals {
+  # Map Lambda's architecture notation to the source image's OS/arch so skopeo
+  # picks the matching image out of the multi-arch index deterministically,
+  # regardless of the host running Terraform.
+  skopeo_platform = {
+    x86_64 = { os = "linux", arch = "amd64" }
+    arm64  = { os = "linux", arch = "arm64" }
+  }[var.architecture]
+}
+
 resource "null_resource" "copy-image" {
   triggers = {
     region           = data.aws_region.current.name
     repository_url   = aws_ecr_repository.repo.repository_url
     source_image_tag = var.source_image_tag
+    architecture     = var.architecture
   }
 
   provisioner "local-exec" {
@@ -19,13 +30,15 @@ resource "null_resource" "copy-image" {
       authfile="$(mktemp)"
       trap 'rm -f "$authfile"' EXIT
       printf '%s' "$DEST_PASSWORD" | skopeo login --username AWS --password-stdin --authfile "$authfile" "$${REPOSITORY_URL%%/*}"
-      skopeo copy --authfile "$authfile" "docker://public.ecr.aws/sorah/himari-lambda:$SOURCE_IMAGE_TAG" "docker://$REPOSITORY_URL:$SOURCE_IMAGE_TAG"
+      skopeo copy --authfile "$authfile" --override-os "$OVERRIDE_OS" --override-arch "$OVERRIDE_ARCH" "docker://public.ecr.aws/sorah/himari-lambda:$SOURCE_IMAGE_TAG" "docker://$REPOSITORY_URL:$SOURCE_IMAGE_TAG"
     EOT
 
     environment = {
       DEST_PASSWORD    = ephemeral.aws_ecr_authorization_token.repo.password
       REPOSITORY_URL   = aws_ecr_repository.repo.repository_url
       SOURCE_IMAGE_TAG = var.source_image_tag
+      OVERRIDE_OS      = local.skopeo_platform.os
+      OVERRIDE_ARCH    = local.skopeo_platform.arch
     }
   }
 }

--- a/himari-aws/lambda/terraform/image/copy.tf
+++ b/himari-aws/lambda/terraform/image/copy.tf
@@ -1,15 +1,29 @@
+ephemeral "aws_ecr_authorization_token" "repo" {
+  registry_id = aws_ecr_repository.repo.registry_id
+}
+
 resource "null_resource" "copy-image" {
   triggers = {
     region           = data.aws_region.current.name
     repository_url   = aws_ecr_repository.repo.repository_url
     source_image_tag = var.source_image_tag
   }
-  provisioner "local-exec" {
-    command = "cd ${path.module} && ./copy.sh"
-    environment = {
-      AWS_REGION         = data.aws_region.current.name
-      AWS_DEFAULT_REGION = data.aws_region.current.name
 
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    # public.ecr.aws is pulled anonymously; only the destination ECR needs credentials.
+    # The password is fed over stdin into a temporary authfile rather than passed as a
+    # command-line argument, so it never appears in the process argument list.
+    command = <<-EOT
+      set -euo pipefail
+      authfile="$(mktemp)"
+      trap 'rm -f "$authfile"' EXIT
+      printf '%s' "$DEST_PASSWORD" | skopeo login --username AWS --password-stdin --authfile "$authfile" "$${REPOSITORY_URL%%/*}"
+      skopeo copy --authfile "$authfile" "docker://public.ecr.aws/sorah/himari-lambda:$SOURCE_IMAGE_TAG" "docker://$REPOSITORY_URL:$SOURCE_IMAGE_TAG"
+    EOT
+
+    environment = {
+      DEST_PASSWORD    = ephemeral.aws_ecr_authorization_token.repo.password
       REPOSITORY_URL   = aws_ecr_repository.repo.repository_url
       SOURCE_IMAGE_TAG = var.source_image_tag
     }

--- a/himari-aws/lambda/terraform/image/copy.tf
+++ b/himari-aws/lambda/terraform/image/copy.tf
@@ -27,6 +27,9 @@ resource "null_resource" "copy-image" {
       set -euo pipefail
       authfile="$(mktemp)"
       trap 'rm -f "$authfile"' EXIT
+      # skopeo login reads the authfile before merging the new credential into it,
+      # so seed it with an empty JSON object; mktemp's 0-byte file is invalid JSON.
+      printf '{}' > "$authfile"
       printf '%s' "$DEST_PASSWORD" | skopeo login --username AWS --password-stdin --authfile "$authfile" "$${REPOSITORY_URL%%/*}"
       skopeo copy --authfile "$authfile" --override-os "$OVERRIDE_OS" --override-arch "$OVERRIDE_ARCH" "docker://public.ecr.aws/sorah/himari-lambda:$SOURCE_IMAGE_TAG" "docker://$REPOSITORY_URL:$SOURCE_IMAGE_TAG"
     EOT

--- a/himari-aws/lambda/terraform/image/variables.tf
+++ b/himari-aws/lambda/terraform/image/variables.tf
@@ -7,3 +7,14 @@ variable "source_image_tag" {
   type        = string
   description = "Image tag for public.ecr.aws/sorah/himari-lambda. You can use Git commit hash on https://github.com/sorah/himari"
 }
+
+variable "architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "Lambda CPU architecture to copy from the multi-arch source image (x86_64 or arm64)"
+
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.architecture)
+    error_message = "architecture must be one of: x86_64, arm64."
+  }
+}

--- a/himari-aws/lambda/terraform/image/versions.tf
+++ b/himari-aws/lambda/terraform/image/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 6.0"
     }
   }
 }

--- a/himari-aws/lambda/terraform/image/versions.tf
+++ b/himari-aws/lambda/terraform/image/versions.tf
@@ -1,7 +1,9 @@
 terraform {
+  required_version = ">= 1.10"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 5.83"
     }
   }
 }


### PR DESCRIPTION
Replace the docker-based image copy in the Lambda terraform with `skopeo`, and bring the modules up to AWS provider v6.

## skopeo migration

- **copy image with skopeo not docker** — replace the docker login/pull/tag/push shell script with a single `skopeo copy` run directly from the `local-exec` provisioner. The destination ECR credential comes from an ephemeral `aws_ecr_authorization_token` so it never lands in state, and is fed over stdin into a temporary authfile rather than a command-line argument to keep it out of the process argument list.
- **copy gains architecture input** — `skopeo copy` defaults to `--multi-arch system`, selecting the image matching the host running Terraform rather than the Lambda's architecture. The new `architecture` input pins the platform via `--override-os/-arch` so the correct single-platform image is copied out of the multi-arch source index regardless of where apply runs. It uses Lambda's notation (x86_64/arm64), mapped to linux/amd64 and linux/arm64 internally.
- **seed authfile so skopeo login can read it** — `mktemp` creates a 0-byte file, but `skopeo login` reads the authfile to merge the new credential before writing it back. An empty file is invalid JSON, so login aborted with `unexpected end of JSON input` and copy-image never ran. The authfile is now seeded with an empty JSON object first.

## AWS provider v6

- **drop registry_id** — the `aws_ecr_authorization_token` ephemeral resource no longer accepts `registry_id` under v6; it only issues a token for the caller's own default registry, which already covers the repo created in the same account.
- **aws_region.current.region** — the `.name` attribute on the `aws_region` data source is deprecated in favor of `.region`. Both modules are pinned to `>= 6.0`.

## Misc

- **terraform/iam: role_name output** — expose the created role name.
- **terraform/README: reflect skopeo-based image copy**.