### PR TITLE
scopes: expose to authz rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ use(Himari::Middlewares::AuthorizationRule, name: 'default') do |context, decisi
   if clients_available_for_everyone.include?(context.client.name)
     next decision.allow!
   end
+
+  # context.scopes carries the recognised scopes requested for this authorization (already
+  # filtered by the client's scopes allow-list), so rules can gate on them.
+  next decision.deny!("admin scope not permitted here") if context.scopes.include?('admin')
+
   decision.skip!
 end
 # we can have many rules

--- a/examples/config.details.ru
+++ b/examples/config.details.ru
@@ -151,6 +151,16 @@ use(Himari::Middlewares::AuthorizationRule, name: 'details') do |context, decisi
   # client
   context.client.name
 
+  # recognised scopes for this authorization (Array<String>), already filtered by the client's
+  # scopes allow-list. On the initial request these come from the request's scope parameter; on
+  # a refresh they are the scopes recorded on the original grant.
+  context.scopes
+
+  # grant type of the request (:initial or :refresh_token); predicates are also available
+  context.grant_type
+  context.initial?
+  context.refresh?
+
   # custom claims per authorization
   decision.claims[:something] = 'these claims merged for specific authorization request'
   # allowed claims (Set). Names not included in allowed_claims will not appear in an outbound ID token.

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -175,8 +175,11 @@ module Himari
       end
 
       if current_user
-        # do downstream authz and process oidc request
-        decision = Himari::Services::DownstreamAuthorization.from_request(session: current_user, client: client, request: request).perform
+        # do downstream authz and process oidc request. The OIDC request's scope is parsed the
+        # same way rack-oauth2 parses it downstream (OidcAuthorizationEndpoint), so the scopes the
+        # authz rules see match those the grant is filtered to.
+        requested_scopes = request.params['scope'].to_s.split(' ')
+        decision = Himari::Services::DownstreamAuthorization.from_request(session: current_user, client: client, request: request, requested_scopes: requested_scopes).perform
         logger&.info(Himari::LogLine.new('authorize: downstream authorized', req: request_as_log, session: current_user.as_log, allowed: decision.authz_result.allowed, result: decision.as_log))
         raise unless decision.authz_result.allowed # sanity check
 

--- a/himari/lib/himari/authorization_code.rb
+++ b/himari/lib/himari/authorization_code.rb
@@ -8,6 +8,7 @@ module Himari
     code
     client_id
     claims
+    scopes
     openid
     offline_access
     session_handle
@@ -84,6 +85,7 @@ module Himari
         client_id: client_id,
         claims: claims,
         nonce: nonce,
+        scopes: scopes,
         openid: openid,
         offline_access: offline_access,
         session_handle: session_handle,
@@ -101,6 +103,7 @@ module Himari
         code: code,
         client_id: client_id,
         claims: claims,
+        scopes: scopes,
         openid: openid,
         offline_access: offline_access,
         session_handle: session_handle,

--- a/himari/lib/himari/decisions/authorization.rb
+++ b/himari/lib/himari/decisions/authorization.rb
@@ -18,7 +18,7 @@ module Himari
         email_verified
       )
 
-      Context = Struct.new(:claims, :user_data, :request, :client, :grant_type, keyword_init: true) do
+      Context = Struct.new(:claims, :user_data, :request, :client, :scopes, :grant_type, keyword_init: true) do
         def initial?; grant_type.nil? || grant_type == :initial; end
         def refresh?; grant_type == :refresh_token; end
       end

--- a/himari/lib/himari/refresh_token.rb
+++ b/himari/lib/himari/refresh_token.rb
@@ -15,12 +15,13 @@ module Himari
       raise ArgumentError, "RefreshToken requires an explicit lifetime:"
     end
 
-    def initialize(handle:, client_id:, claims:, session_handle:, expiry:, openid: false, secret: nil, secret_hash: nil, secret_hash_prev: nil, version: 1, updated_at: nil)
+    def initialize(handle:, client_id:, claims:, session_handle:, expiry:, openid: false, scopes: [], secret: nil, secret_hash: nil, secret_hash_prev: nil, version: 1, updated_at: nil)
       @handle = handle
       @client_id = client_id
       @claims = claims
       @session_handle = session_handle
       @openid = openid
+      @scopes = scopes
       @expiry = expiry
 
       @secret = secret
@@ -31,7 +32,7 @@ module Himari
       @verification = nil
     end
 
-    attr_reader :handle, :client_id, :claims, :session_handle, :openid, :expiry, :version, :updated_at
+    attr_reader :handle, :client_id, :claims, :session_handle, :openid, :scopes, :expiry, :version, :updated_at
 
     # Rotate the token in place (same handle): mint a new current secret while keeping the
     # just-presented secret valid as the previous one, so a client whose rotation response is
@@ -49,6 +50,7 @@ module Himari
         session_handle:,
         claims:,
         openid:,
+        scopes:,
         secret: SecureRandom.urlsafe_base64(48),
         secret_hash_prev: verification.secret_hash,
         version: version + 1,
@@ -64,6 +66,7 @@ module Himari
         claims: claims,
         session_handle: session_handle,
         openid: openid,
+        scopes: scopes,
         expiry: expiry,
         version: version,
         updated_at: updated_at,
@@ -80,6 +83,7 @@ module Himari
         claims: claims,
         session_handle: session_handle,
         openid: openid,
+        scopes: scopes,
         expiry: expiry.to_i,
         version: version,
         updated_at: updated_at.to_i,

--- a/himari/lib/himari/services/downstream_authorization.rb
+++ b/himari/lib/himari/services/downstream_authorization.rb
@@ -23,11 +23,12 @@ module Himari
         end
       end
 
-      Result = Struct.new(:client, :claims, :lifetime, :authz_result) do
+      Result = Struct.new(:client, :claims, :scopes, :lifetime, :authz_result) do
         def as_log
           {
             client: client.as_log,
             claims: claims,
+            scopes: scopes,
             decision: {
               authorization: authz_result.as_log,
             },
@@ -37,14 +38,19 @@ module Himari
 
       # @param session [Himari::SessionData]
       # @param client [Himari::ClientRegistration]
-      # @param request [Rack::Request]
+      # @param request [Rack::Request] exposed to rules as context.request (an escape hatch); the
+      #   engine never reads it, so requested scopes are supplied explicitly, never derived from it.
+      # @param requested_scopes [Array<String>] scopes asked for, before the client's allow-list
+      #   filter. The caller supplies them from the appropriate source: the authorization endpoint
+      #   passes the request's parsed scope, the refresh flow the scopes recorded on the grant.
       # @param authz_rules [Array<Himari::Rule>] Authorization Rules
       # @param logger [Logger]
-      def initialize(session:, client:, grant_type: :initial, request: nil, authz_rules: [], logger: nil)
+      def initialize(session:, client:, requested_scopes:, grant_type: :initial, request: nil, authz_rules: [], logger: nil)
         @session = session
         @client = client
         @grant_type = grant_type
         @request = request
+        @requested_scopes = requested_scopes
         @authz_rules = authz_rules
         @logger = logger
       end
@@ -52,26 +58,29 @@ module Himari
       # @param session [Himari::SessionData]
       # @param client [Himari::ClientRegistration]
       # @param request [Rack::Request]
-      def self.from_request(session:, client:, request:, grant_type: :initial)
+      # @param requested_scopes [Array<String>] see #initialize; always supplied by the caller
+      def self.from_request(session:, client:, request:, requested_scopes:, grant_type: :initial)
         new(
           session: session,
           client: client,
           grant_type: grant_type,
           request: request,
+          requested_scopes: requested_scopes,
           authz_rules: Himari::ProviderChain.new(request.env[Himari::Middlewares::AuthorizationRule::RACK_KEY] || []).collect,
           logger: request.env['rack.logger'],
         )
       end
 
       def perform
-        context = Himari::Decisions::Authorization::Context.new(claims: @session.claims, user_data: @session.user_data, request: @request, client: @client, grant_type: @grant_type).freeze
+        scopes = @client.filter_scopes(@requested_scopes)
+        context = Himari::Decisions::Authorization::Context.new(claims: @session.claims, user_data: @session.user_data, request: @request, client: @client, scopes: scopes, grant_type: @grant_type).freeze
 
         authorization = Himari::RuleProcessor.new(context, Himari::Decisions::Authorization.new(claims: @session.claims.dup)).run(@authz_rules)
-        raise ForbiddenError.new(Result.new(@client, nil, nil, authorization)) unless authorization.allowed
+        raise ForbiddenError.new(Result.new(@client, nil, scopes, nil, authorization)) unless authorization.allowed
 
         claims = authorization.decision.output_claims
         lifetime = authorization.decision.lifetime
-        Result.new(@client, claims, lifetime, authorization)
+        Result.new(@client, claims, scopes, lifetime, authorization)
       end
     end
   end

--- a/himari/lib/himari/services/oidc_authorization_endpoint.rb
+++ b/himari/lib/himari/services/oidc_authorization_endpoint.rb
@@ -102,6 +102,7 @@ module Himari
             @authz.redirect_uri = res.redirect_uri
             @authz.nonce = req.nonce
 
+            @authz.scopes = scopes
             @authz.openid = scopes.include?('openid')
             @authz.offline_access = scopes.include?('offline_access')
             if req.code_challenge && req.code_challenge_method

--- a/himari/lib/himari/services/oidc_token_endpoint.rb
+++ b/himari/lib/himari/services/oidc_token_endpoint.rb
@@ -106,7 +106,7 @@ module Himari
 
         refresh = nil
         if authz.offline_access && authz.session_handle && authz.lifetime&.refresh_token
-          refresh = RefreshToken.make(client_id: client.id, claims: authz.claims, session_handle: authz.session_handle, openid: authz.openid, lifetime: authz.lifetime.refresh_token)
+          refresh = RefreshToken.make(client_id: client.id, claims: authz.claims, session_handle: authz.session_handle, openid: authz.openid, scopes: authz.scopes, lifetime: authz.lifetime.refresh_token)
           @storage.put_refresh_token(refresh)
         end
 
@@ -170,7 +170,7 @@ module Himari
         updated_session = authn.session_data
 
         begin
-          downstream = Himari::Services::DownstreamAuthorization.from_request(session: updated_session, client: client, request: rack_request, grant_type: :refresh_token).perform
+          downstream = Himari::Services::DownstreamAuthorization.from_request(session: updated_session, client: client, request: rack_request, grant_type: :refresh_token, requested_scopes: refresh.scopes).perform
         rescue Himari::Services::DownstreamAuthorization::ForbiddenError => e
           return reject_refresh!(env, req, client, 'refresh downstream authz denied', refresh: refresh, session: updated_session.as_log, result: e.as_log)
         end

--- a/himari/spec/himari/authorization_code_spec.rb
+++ b/himari/spec/himari/authorization_code_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe Himari::AuthorizationCode do
 
   describe "session_handle and offline_access" do
     specify "round-trip through as_json" do
-      code = described_class.make(client_id: 'cli', claims: {sub: 'c'}, openid: true, offline_access: true, session_handle: 'sess', redirect_uri: 'https://r.invalid/cb', lifetime: Himari::LifetimeValue.from_integer(60))
+      code = described_class.make(client_id: 'cli', claims: {sub: 'c'}, scopes: %w(openid profile offline_access), openid: true, offline_access: true, session_handle: 'sess', redirect_uri: 'https://r.invalid/cb', lifetime: Himari::LifetimeValue.from_integer(60))
       json = JSON.parse(JSON.dump(code.as_json), symbolize_names: true)
       restored = described_class.new(**json)
       expect(restored.session_handle).to eq('sess')
       expect(restored.offline_access).to eq(true)
       expect(restored.openid).to eq(true)
+      expect(restored.scopes).to eq(%w(openid profile offline_access))
     end
   end
 

--- a/himari/spec/himari/refresh_token_spec.rb
+++ b/himari/spec/himari/refresh_token_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Himari::RefreshToken do
         claims: {sub: 'c'},
         session_handle: 'sess',
         openid: true,
+        scopes: %w(openid profile),
         lifetime: 7200,
       )
     end
@@ -19,6 +20,7 @@ RSpec.describe Himari::RefreshToken do
       expect(r.client_id).to eq('cli')
       expect(r.claims).to eq(sub: 'c')
       expect(r.openid).to eq(true)
+      expect(r.scopes).to eq(%w(openid profile))
       expect(r.session_handle).to eq('sess')
       expect(r.handle).to be_a(String)
       expect(r.secret).to be_a(String)
@@ -37,6 +39,7 @@ RSpec.describe Himari::RefreshToken do
       expect(restored.client_id).to eq(r.client_id)
       expect(restored.session_handle).to eq(r.session_handle)
       expect(restored.openid).to eq(true)
+      expect(restored.scopes).to eq(%w(openid profile))
       expect(restored.verify_secret!(r.secret)).to eq(true)
     end
 
@@ -48,14 +51,14 @@ RSpec.describe Himari::RefreshToken do
     end
 
     specify "as_log omits secrets and reports prev_secret_set" do
-      expect(r.as_log.keys).to contain_exactly(:handle, :client_id, :claims, :session_handle, :openid, :expiry, :version, :updated_at, :prev_secret_set)
+      expect(r.as_log.keys).to contain_exactly(:handle, :client_id, :claims, :session_handle, :openid, :scopes, :expiry, :version, :updated_at, :prev_secret_set)
       expect(r.as_log).to include(prev_secret_set: false)
     end
   end
 
   describe "#rotate" do
     subject(:original) do
-      described_class.make(client_id: 'cli', claims: {sub: 'c'}, session_handle: 'sess', openid: true, lifetime: 7200)
+      described_class.make(client_id: 'cli', claims: {sub: 'c'}, session_handle: 'sess', openid: true, scopes: %w(openid profile), lifetime: 7200)
     end
 
     subject(:rotated) do
@@ -74,6 +77,10 @@ RSpec.describe Himari::RefreshToken do
       # expiry is the absolute cap from initial issuance, not slid forward on rotation
       expect(rotated.expiry).to eq(original.expiry)
       expect(rotated.claims).to eq(sub: 'c2')
+    end
+
+    specify "preserves the granted scopes across rotation" do
+      expect(rotated.scopes).to eq(%w(openid profile))
     end
 
     specify "issues a fresh secret and keeps the presented secret valid as previous" do

--- a/himari/spec/himari/services/downstream_authorization_spec.rb
+++ b/himari/spec/himari/services/downstream_authorization_spec.rb
@@ -4,11 +4,13 @@ require 'spec_helper'
 
 require 'himari/services/downstream_authorization'
 require 'himari/rule'
+require 'himari/item_providers/static'
+require 'himari/middlewares/authorization_rule'
 
 RSpec.describe Himari::Services::DownstreamAuthorization do
-  let(:rack_request) { double('rack request') }
+  let(:rack_request) { double('rack request', params: {'scope' => 'openid profile email'}) }
   let(:session_data) { double('session data', claims: {claims: 1}, user_data: {user_data: 1}) }
-  let(:client) { double('client registration') }
+  let(:client) { double('client registration', filter_scopes: %w(openid profile)) }
 
   let(:authz_rules) do
     [
@@ -16,7 +18,8 @@ RSpec.describe Himari::Services::DownstreamAuthorization do
     ]
   end
 
-  subject(:service) { described_class.new(session: session_data, client: client, request: rack_request, authz_rules: authz_rules) }
+  let(:requested_scopes) { %w(openid profile email) }
+  subject(:service) { described_class.new(session: session_data, client: client, request: rack_request, requested_scopes: requested_scopes, authz_rules: authz_rules) }
   subject(:result) { service.perform }
 
   describe "nominal case" do
@@ -27,6 +30,7 @@ RSpec.describe Himari::Services::DownstreamAuthorization do
           expect(c.claims[:claims]).to eq(1)
           expect(c.user_data[:user_data]).to eq(1)
           expect(c.request).to eq(rack_request)
+          expect(c.scopes).to eq(%w(openid profile))
 
           expect(d.claims[:claims]).to eq(1)
           d.allowed_claims.push(:claims, :new_claims)
@@ -42,9 +46,50 @@ RSpec.describe Himari::Services::DownstreamAuthorization do
       expect(client).to receive(:ok)
       expect(result.client).to eq(client)
       expect(result.claims).to eq(claims: 2, new_claims: 2)
+      expect(result.scopes).to eq(%w(openid profile))
       expect(result.lifetime.access_token).to eq(12345)
       expect(result.lifetime.id_token).to eq(12345)
       expect(result.authz_result.allowed).to eq(true)
+    end
+  end
+
+  describe "scope filtering" do
+    it "filters the requested scopes through the client's allow-list and exposes them to rules" do
+      expect(client).to receive(:filter_scopes).with(%w(openid profile email)).and_return(%w(openid profile))
+      seen = nil
+      rules = [Himari::Rule.new(name: 'allow', block: proc { |c, d|
+        seen = c.scopes
+        d.allow!
+      })]
+      result = described_class.new(session: session_data, client: client, request: rack_request, requested_scopes: %w(openid profile email), authz_rules: rules).perform
+      expect(seen).to eq(%w(openid profile))
+      expect(result.scopes).to eq(%w(openid profile))
+    end
+
+    it "never reads the request object to derive scopes (it is only a rule escape hatch)" do
+      expect(rack_request).not_to receive(:params)
+      allow(client).to receive(:filter_scopes).and_return([])
+      described_class.new(session: session_data, client: client, request: rack_request, requested_scopes: %w(profile), authz_rules: [Himari::Rule.new(name: 'allow', block: proc { |_c, d| d.allow! })]).perform
+    end
+  end
+
+  describe ".from_request" do
+    let(:allow_rule) { Himari::Rule.new(name: 'allow', block: proc { |_c, d| d.allow! }) }
+    let(:env) { {Himari::Middlewares::AuthorizationRule::RACK_KEY => [Himari::ItemProviders::Static.new([allow_rule])], 'rack.logger' => nil} }
+    let(:request) { double('request', env: env) }
+
+    it "wires the authz rules from the request env and forwards the caller's scopes" do
+      expect(request).not_to receive(:params)
+      expect(client).to receive(:filter_scopes).with(%w(openid profile)).and_return(%w(openid profile))
+      seen = nil
+      env[Himari::Middlewares::AuthorizationRule::RACK_KEY] = [Himari::ItemProviders::Static.new([
+        Himari::Rule.new(name: 'allow', block: proc { |c, d|
+          seen = c.scopes
+          d.allow!
+        }),
+      ])]
+      described_class.from_request(session: session_data, client: client, request: request, requested_scopes: %w(openid profile)).perform
+      expect(seen).to eq(%w(openid profile))
     end
   end
 

--- a/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
@@ -79,8 +79,20 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
       expect(authz.redirect_uri).to eq('https://rp.invalid/cb')
       expect(authz.nonce).to eq('nn')
       expect(authz.openid).to eq(true)
+      expect(authz.scopes).to eq(%w(openid))
       expect(authz.code_challenge).to be_nil
       expect(authz.code_challenge_method).to be_nil
+    end
+
+    context "when the client declares an extra scope" do
+      let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, skip_consent:, scopes: %w(profile)) }
+
+      it "persists only the recognised scopes onto the AuthorizationCode" do
+        get '/oidc/authorize?client_id=clientid&response_type=code&scope=openid+profile+email&state=x&redirect_uri=https%3A%2F%2Frp.invalid%2Fcb&nonce=nn'
+        query = Addressable::URI.parse(last_response.headers['location']).query_values
+        stored = storage.find_authorization(query['code'])
+        expect(stored.scopes).to eq(%w(openid profile))
+      end
     end
 
     context "when pkce enforced" do

--- a/himari/spec/himari/services/oidc_token_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_token_endpoint_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
   let(:client) do
     double('client', id: 'clientid', redirect_uris: ['https://rp.invalid/cb'], preferred_key_group: 'kagi', as_log: {client_as_log: 1}, require_pkce: require_pkce, confidential?: confidential).tap do |x|
       allow(x).to receive(:match_secret?).with('secret').and_return(true)
+      allow(x).to receive(:filter_scopes) { |requested| requested }
     end
   end
   let(:client_provider) do
@@ -213,7 +214,7 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
 
     context "with offline_access scope and lifetime.refresh_token set" do
       let(:lifetime_value) { Himari::LifetimeValue.new(id_token: 3600, access_token: 3600, refresh_token: 7200) }
-      let(:authz) { Himari::AuthorizationCode.make(client_id: 'clientid', claims: {sub: 'chihiro'}, redirect_uri: 'https://rp.invalid/cb', openid: scope_openid, offline_access: true, session_handle: 'sess1', lifetime: lifetime_value) }
+      let(:authz) { Himari::AuthorizationCode.make(client_id: 'clientid', claims: {sub: 'chihiro'}, redirect_uri: 'https://rp.invalid/cb', openid: scope_openid, offline_access: true, scopes: %w(openid offline_access profile), session_handle: 'sess1', lifetime: lifetime_value) }
 
       it "issues a refresh_token persisted in storage" do
         post '/oidc/token', 'grant_type' => 'authorization_code', 'code' => authz.code, 'redirect_uri' => 'https://rp.invalid/cb'
@@ -227,6 +228,8 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
         expect(stored.verify_secret!(parsed.secret)).to eq(true)
         expect(stored.session_handle).to eq('sess1')
         expect(stored.client_id).to eq('clientid')
+        # the grant's scopes are carried onto the refresh token for later refreshes
+        expect(stored.scopes).to eq(%w(openid offline_access profile))
       end
 
       it "skips refresh_token when session_handle missing" do
@@ -294,6 +297,7 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
         claims: {sub: 'chihiro'},
         session_handle: session.handle,
         openid: false,
+        scopes: %w(profile),
         lifetime: 7200,
       )
     end
@@ -355,6 +359,24 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
       expect(stored.verify_secret!(new_parsed.secret)).to eq(true)
       # ...and still against the just-presented (now previous) secret.
       expect(storage.find_refresh_token(refresh.handle).verify_secret!(refresh.secret)).to eq(true)
+    end
+
+    it "exposes the grant's scopes to authz rules and preserves them across rotation" do
+      seen = nil
+      env = {
+        Himari::Middlewares::AuthorizationRule::RACK_KEY => [Himari::ItemProviders::Static.new([
+          Himari::Rule.new(name: 'authz', block: proc { |c, d|
+            seen = c.scopes
+            d.lifetime = Himari::LifetimeValue.new(access_token: 3600, id_token: 3600, refresh_token: 7200)
+            d.allow!
+          }),
+        ])],
+      }
+      # The refresh request carries no scope parameter, so the scopes must come from the grant.
+      post_refresh(refresh.format.to_s, env)
+      expect(last_response.status).to eq(200)
+      expect(seen).to eq(%w(profile))
+      expect(storage.find_refresh_token(refresh.handle).scopes).to eq(%w(profile))
     end
 
     it "tolerates a lost rotation response: the previous secret refreshes once more" do


### PR DESCRIPTION
Follow-up to the per-client scopes allow-list (#17). The recognised scopes of an authorization request were dropped once openid and offline_access had been gated; retain them so authz rules can act on them and operators can audit what was granted, on both the initial and the refresh flow.

- AuthorizationCode gains a scopes member, serialized through as_json (round-trips storage) and as_log. Older records without the key deserialize to nil.
- DownstreamAuthorization exposes the recognised scopes to the rules as context.scopes (and carries them on its Result). requested_scopes is a required argument the caller always supplies from the appropriate source: the authorization endpoint passes the OIDC request's parsed scope (split the same way rack-oauth2 parses it downstream), the refresh flow the scopes recorded on the grant. The engine never reads the request for scopes; context.request stays purely a rule escape hatch. Either source is filtered through the client's allow-list, so a scope dropped from the client since issuance falls away on refresh.
- OidcAuthorizationEndpoint records the filtered scopes onto the AuthorizationCode it persists.
- RefreshToken gains a scopes member, minted from the AuthorizationCode and preserved across rotation; older records default to an empty set.