### PR TITLE
access-token: opt-in RFC 9068 JWT format

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ use(Himari::Middlewares::AuthorizationRule, name: 'default') do |context, decisi
   # filtered by the client's scopes allow-list), so rules can gate on them.
   next decision.deny!("admin scope not permitted here") if context.scopes.include?('admin')
 
+  # Issue the access token as a signed RFC 9068 JWT (at+jwt) for relying parties that validate
+  # it themselves; Himari still validates it against storage. Opaque by default.
+  decision.mint_jwt_access_token = true if context.client.name == 'api'
+
   decision.skip!
 end
 # we can have many rules

--- a/examples/config.details.ru
+++ b/examples/config.details.ru
@@ -172,6 +172,11 @@ use(Himari::Middlewares::AuthorizationRule, name: 'details') do |context, decisi
   decision.lifetime.access_token = 86400
   decision.lifetime.id_token = 900
 
+  # Issue the access token as a signed RFC 9068 JWT (at+jwt) carrying the same claims as the ID
+  # token, instead of an opaque token. Himari still validates it against storage, so revocation
+  # and lifetime behave identically. Default false.
+  decision.mint_jwt_access_token = true
+
   # Rule must always call one of the followings
   next decision.deny! # explicit deny, stop processing
   next decision.allow! # allow, continues processing

--- a/himari/lib/himari/access_token.rb
+++ b/himari/lib/himari/access_token.rb
@@ -2,8 +2,10 @@
 
 require 'rack/oauth2'
 require 'openid_connect'
+require 'json/jwt'
 
 require 'himari/token_string'
+require 'himari/access_token_jwt'
 
 module Himari
   class AccessToken
@@ -25,20 +27,57 @@ module Himari
       3600
     end
 
+    # Parse a presented access token into its opaque Format (handle + secret) for verification
+    # against storage. Two on-the-wire shapes are accepted:
+    #
+    # - the opaque token "hmat.<handle>.<secret>" (TokenString format), or
+    # - an RFC 9068 JWT (Himari::AccessTokenJwt) carrying the opaque token in its +hmat+ claim.
+    #
+    # For a JWT, the signature is verified first (requires signing_key_provider to resolve the
+    # kid), then the embedded opaque token is returned so the caller validates the secret against
+    # storage exactly as for an opaque token. Any malformed/unverifiable JWT becomes
+    # TokenString::InvalidFormat so callers handle one failure type.
+    #
+    # @param signing_key_provider [Himari::ProviderChain<Himari::SigningKey>, nil]
+    def self.parse(str, signing_key_provider: nil)
+      return TokenString::Format.parse(magic_header, str) if str.to_s.start_with?("#{magic_header}.")
+
+      parse_jwt(str, signing_key_provider)
+    end
+
+    def self.parse_jwt(str, signing_key_provider)
+      raise TokenString::InvalidFormat, 'signing keys are required to verify a JWT access token' unless signing_key_provider
+
+      jwt = JSON::JWT.decode(str, :skip_verification)
+      key = jwt.kid && signing_key_provider.find(id: jwt.kid)
+      raise TokenString::InvalidFormat, 'unknown or missing signing key (kid)' unless key
+
+      jwt.verify!(key.pkey)
+
+      hmat = jwt[magic_header]
+      raise TokenString::InvalidFormat, 'missing hmat claim' unless hmat.is_a?(String) && hmat.start_with?("#{magic_header}.")
+
+      TokenString::Format.parse(magic_header, hmat)
+    rescue JSON::JWT::Exception, JSON::ParserError => e
+      raise TokenString::InvalidFormat, "invalid JWT access token: #{e.class}"
+    end
+
     # @param authz [Himari::AuthorizationCode]
     def self.from_authz(authz)
       make(
         client_id: authz.client_id,
         claims: authz.claims,
+        scopes: authz.scopes,
         session_handle: authz.session_handle,
         lifetime: authz.lifetime.access_token,
       )
     end
 
-    def initialize(handle:, client_id:, claims:, expiry:, session_handle: nil, secret: nil, secret_hash: nil)
+    def initialize(handle:, client_id:, claims:, expiry:, scopes: [], session_handle: nil, secret: nil, secret_hash: nil)
       @handle = handle
       @client_id = client_id
       @claims = claims
+      @scopes = scopes
       @session_handle = session_handle
       @expiry = expiry
 
@@ -48,7 +87,7 @@ module Himari
       @verification = nil
     end
 
-    attr_reader :handle, :client_id, :claims, :session_handle, :expiry
+    attr_reader :handle, :client_id, :claims, :scopes, :session_handle, :expiry
 
     def userinfo
       claims.merge(
@@ -56,11 +95,30 @@ module Himari
       )
     end
 
-    def to_bearer
+    # @param token_string [String] the on-the-wire access token to deliver. Defaults to the
+    #   opaque format; the token endpoint passes the RFC 9068 JWT when one was minted.
+    def to_bearer(token_string: format.to_s)
       Bearer.new(
-        access_token: format.to_s,
+        access_token: token_string,
         expires_in: (expiry - Time.now.to_i).to_i,
       )
+    end
+
+    # Render this token as an RFC 9068 JWT (Himari::AccessTokenJwt). The opaque secret travels in
+    # the JWT's hmat claim, so the token validates against storage the same way either form does.
+    # exp is tied to this token's own expiry rather than recomputed, keeping both forms in sync.
+    # @param signing_key [Himari::SigningKey]
+    # @param issuer [String]
+    def to_jwt(signing_key:, issuer:, now: Time.now)
+      AccessTokenJwt.new(
+        access: self,
+        claims: claims,
+        client_id: client_id,
+        signing_key: signing_key,
+        issuer: issuer,
+        time: now,
+        lifetime: expiry - now.to_i,
+      ).to_jwt
     end
 
     def as_log
@@ -68,6 +126,7 @@ module Himari
         handle: handle,
         client_id: client_id,
         claims: claims,
+        scopes: scopes,
         session_handle: session_handle,
         expiry: expiry,
       }
@@ -79,6 +138,7 @@ module Himari
         secret_hash: secret_hash,
         client_id: client_id,
         claims: claims,
+        scopes: scopes,
         session_handle: session_handle,
         expiry: expiry.to_i,
       }

--- a/himari/lib/himari/access_token_jwt.rb
+++ b/himari/lib/himari/access_token_jwt.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'himari/jwt_token'
+require 'himari/access_token'
+
+module Himari
+  # RFC 9068 (JWT Profile for OAuth 2.0 Access Tokens) representation of an access token. The
+  # signed JWT carries the same IdP claims as the ID Token for relying parties to consume
+  # directly, plus the registered claims RFC 9068 requires. Himari still authenticates the token
+  # by the opaque secret embedded in the +hmat+ claim (see Himari::AccessToken.parse), so the
+  # JWT signature is an additional, self-contained guarantee for relying parties.
+  class AccessTokenJwt < JwtToken
+    # sub is the one RFC 9068 §2.2 required claim sourced from variable IdP claims rather than set
+    # by us; fail closed at mint time if a misconfigured allowed_claims stripped it.
+    class MissingSubject < StandardError; end
+
+    # @param access [Himari::AccessToken] the minted, persisted opaque access token this JWT wraps
+    def initialize(access:, **kwargs)
+      super(**kwargs)
+      @access = access
+    end
+
+    # https://www.rfc-editor.org/rfc/rfc9068.html#section-2.1
+    def jwt_header
+      {typ: 'at+jwt'}
+    end
+
+    # https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2
+    def final_claims
+      raise MissingSubject, 'RFC 9068 access token requires a sub claim' unless claims[:sub]
+
+      standard_claims.merge(
+        client_id: @client_id,
+        jti: @access.handle,
+        # The opaque access token Himari validates against storage; relying parties ignore it.
+        AccessToken.magic_header.to_sym => @access.format.to_s,
+      ).merge(scope_claim)
+    end
+
+    # https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2.1 — space-delimited granted scopes.
+    private def scope_claim
+      scopes = @access.scopes
+      scopes && !scopes.empty? ? {scope: scopes.join(' ')} : {}
+    end
+  end
+end

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -187,6 +187,7 @@ module Himari
           client_id: decision.client.id,
           claims: decision.claims,
           lifetime: decision.lifetime,
+          mint_jwt_access_token: decision.mint_jwt_access_token,
           session_handle: current_user.handle,
         )
 
@@ -249,6 +250,7 @@ module Himari
     userinfo_ep = proc do
       Himari::Services::OidcUserinfoEndpoint.new(
         storage: config.storage,
+        signing_key_provider: signing_key_provider,
         logger: logger,
       ).call(env)
     end

--- a/himari/lib/himari/authorization_code.rb
+++ b/himari/lib/himari/authorization_code.rb
@@ -9,6 +9,7 @@ module Himari
     client_id
     claims
     scopes
+    mint_jwt_access_token
     openid
     offline_access
     session_handle
@@ -86,6 +87,7 @@ module Himari
         claims: claims,
         nonce: nonce,
         scopes: scopes,
+        mint_jwt_access_token: mint_jwt_access_token,
         openid: openid,
         offline_access: offline_access,
         session_handle: session_handle,
@@ -104,6 +106,7 @@ module Himari
         client_id: client_id,
         claims: claims,
         scopes: scopes,
+        mint_jwt_access_token: mint_jwt_access_token,
         openid: openid,
         offline_access: offline_access,
         session_handle: session_handle,

--- a/himari/lib/himari/decisions/authorization.rb
+++ b/himari/lib/himari/decisions/authorization.rb
@@ -25,15 +25,20 @@ module Himari
 
       allow_effects(:allow, :deny, :continue, :skip)
 
-      def initialize(claims: {}, allowed_claims: DEFAULT_ALLOWED_CLAIMS, lifetime: 3600)
+      def initialize(claims: {}, allowed_claims: DEFAULT_ALLOWED_CLAIMS, lifetime: 3600, mint_jwt_access_token: false)
         super()
         @claims = claims
         @allowed_claims = allowed_claims
+        @mint_jwt_access_token = mint_jwt_access_token
         self.lifetime = lifetime
       end
 
       attr_reader :claims, :allowed_claims
       attr_reader :lifetime
+
+      # When set by an authz rule, the issued access token is an RFC 9068 JWT instead of an
+      # opaque token (the token is still tracked and validated against storage either way).
+      attr_accessor :mint_jwt_access_token
 
       def lifetime=(x)
         @lifetime = case x
@@ -49,11 +54,12 @@ module Himari
           claims: @claims.dup,
           allowed_claims: @allowed_claims.dup,
           lifetime: @lifetime,
+          mint_jwt_access_token: @mint_jwt_access_token,
         }
       end
 
       def as_log
-        to_h.merge(claims: output_claims, lifetime: @lifetime.to_h)
+        to_h.merge(claims: output_claims, lifetime: @lifetime.to_h, mint_jwt_access_token: @mint_jwt_access_token)
       end
 
       def output_claims

--- a/himari/lib/himari/id_token.rb
+++ b/himari/lib/himari/id_token.rb
@@ -5,8 +5,10 @@ require 'openid_connect'
 require 'base64'
 require 'json/jwt'
 
+require 'himari/jwt_token'
+
 module Himari
-  class IdToken
+  class IdToken < JwtToken
     # @param authz [Himari::AuthorizationCode]
     def self.from_authz(authz, **kwargs)
       new(
@@ -18,28 +20,17 @@ module Himari
       )
     end
 
-    def initialize(claims:, client_id:, nonce:, signing_key:, issuer:, access_token: nil, time: Time.now, lifetime: 3600)
-      @claims = claims
-      @client_id = client_id
+    def initialize(nonce:, access_token: nil, **kwargs)
+      super(**kwargs)
       @nonce = nonce
-      @signing_key = signing_key
-      @issuer = issuer
       @access_token = access_token
-      @time = time
-      @lifetime = lifetime
     end
 
-    attr_reader :claims, :nonce, :signing_key
+    attr_reader :nonce
 
     def final_claims
       # https://openid.net/specs/openid-connect-core-1_0.html#IDToken
-      claims.merge(
-        iss: @issuer,
-        aud: @client_id,
-        iat: @time.to_i,
-        nbf: @time.to_i,
-        exp: (@time + @lifetime).to_i,
-      ).merge(
+      standard_claims.merge(
         @nonce ? {nonce: @nonce} : {},
       ).merge(
         @access_token ? {at_hash: at_hash} : {},
@@ -49,14 +40,8 @@ module Himari
     def at_hash
       return unless @access_token
 
-      dgst = @signing_key.hash_function.digest(@access_token)
+      dgst = signing_key.hash_function.digest(@access_token)
       Base64.urlsafe_encode64(dgst[0, dgst.size / 2], padding: false)
-    end
-
-    def to_jwt
-      jwt = JSON::JWT.new(final_claims)
-      jwt.kid = @signing_key.id
-      jwt.sign(@signing_key.pkey, @signing_key.alg.to_sym).to_s
     end
   end
 end

--- a/himari/lib/himari/jwt_token.rb
+++ b/himari/lib/himari/jwt_token.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'json/jwt'
+
+module Himari
+  # Shared minting process for the JWTs Himari signs for relying parties: the OIDC ID Token
+  # and the RFC 9068 access token. Holds the common claim derivation (registered claims merged
+  # over the IdP claims) and the signing step (kid, optional JOSE header fields, signature).
+  # Subclasses add their token-specific claims/header by overriding #final_claims / #jwt_header.
+  class JwtToken
+    def initialize(claims:, client_id:, signing_key:, issuer:, time: Time.now, lifetime: 3600)
+      @claims = claims
+      @client_id = client_id
+      @signing_key = signing_key
+      @issuer = issuer
+      @time = time
+      @lifetime = lifetime
+    end
+
+    attr_reader :claims, :client_id, :signing_key, :issuer
+
+    # Registered claims common to every Himari-minted JWT. The IdP claims (sub and the rest) are
+    # carried verbatim so the access token exposes the same claim set as the ID Token.
+    def standard_claims
+      claims.merge(
+        iss: @issuer,
+        aud: @client_id,
+        iat: @time.to_i,
+        nbf: @time.to_i,
+        exp: (@time + @lifetime).to_i,
+      )
+    end
+
+    def final_claims
+      standard_claims
+    end
+
+    # JOSE header fields beyond kid; subclasses override (e.g. typ=at+jwt for RFC 9068).
+    def jwt_header
+      {}
+    end
+
+    def to_jwt
+      jwt = JSON::JWT.new(final_claims)
+      jwt.kid = @signing_key.id
+      jwt_header.each { |k, v| jwt.header[k] = v }
+      jwt.sign(@signing_key.pkey, @signing_key.alg.to_sym).to_s
+    end
+  end
+end

--- a/himari/lib/himari/services/downstream_authorization.rb
+++ b/himari/lib/himari/services/downstream_authorization.rb
@@ -23,12 +23,13 @@ module Himari
         end
       end
 
-      Result = Struct.new(:client, :claims, :scopes, :lifetime, :authz_result) do
+      Result = Struct.new(:client, :claims, :scopes, :lifetime, :mint_jwt_access_token, :authz_result) do
         def as_log
           {
             client: client.as_log,
             claims: claims,
             scopes: scopes,
+            mint_jwt_access_token: mint_jwt_access_token,
             decision: {
               authorization: authz_result.as_log,
             },
@@ -76,11 +77,12 @@ module Himari
         context = Himari::Decisions::Authorization::Context.new(claims: @session.claims, user_data: @session.user_data, request: @request, client: @client, scopes: scopes, grant_type: @grant_type).freeze
 
         authorization = Himari::RuleProcessor.new(context, Himari::Decisions::Authorization.new(claims: @session.claims.dup)).run(@authz_rules)
-        raise ForbiddenError.new(Result.new(@client, nil, scopes, nil, authorization)) unless authorization.allowed
+        raise ForbiddenError.new(Result.new(@client, nil, scopes, nil, nil, authorization)) unless authorization.allowed
 
         claims = authorization.decision.output_claims
         lifetime = authorization.decision.lifetime
-        Result.new(@client, claims, scopes, lifetime, authorization)
+        mint_jwt_access_token = authorization.decision.mint_jwt_access_token
+        Result.new(@client, claims, scopes, lifetime, mint_jwt_access_token, authorization)
       end
     end
   end

--- a/himari/lib/himari/services/oidc_token_endpoint.rb
+++ b/himari/lib/himari/services/oidc_token_endpoint.rb
@@ -15,7 +15,7 @@ module Himari
     class OidcTokenEndpoint
       class SigningKeyMissing < StandardError; end
 
-      Issued = Struct.new(:access, :id_token_jwt, :signing_key, keyword_init: true)
+      Issued = Struct.new(:access, :access_token_string, :id_token_jwt, :signing_key, keyword_init: true)
 
       # @param client_provider [Himari::ProviderChain<Himari::ClientRegistration>]
       # @param signing_key_provider [Himari::ProviderChain<Himari::SigningKey>]
@@ -98,10 +98,12 @@ module Himari
         issued = issue_access_and_id(
           client: client,
           claims: authz.claims,
+          scopes: authz.scopes,
           lifetime: authz.lifetime,
           openid: authz.openid,
           session_handle: authz.session_handle,
           nonce: authz.nonce,
+          mint_jwt_access_token: authz.mint_jwt_access_token,
         )
 
         refresh = nil
@@ -110,7 +112,7 @@ module Himari
           @storage.put_refresh_token(refresh)
         end
 
-        bearer = issued.access.to_bearer
+        bearer = issued.access.to_bearer(token_string: issued.access_token_string)
         bearer.refresh_token = refresh.format.to_s if refresh
         res.access_token = bearer
         res.id_token = issued.id_token_jwt if issued.id_token_jwt
@@ -202,13 +204,15 @@ module Himari
         issued = issue_access_and_id(
           client: client,
           claims: downstream.claims,
+          scopes: downstream.scopes,
           lifetime: downstream.lifetime,
           openid: refresh.openid,
           session_handle: updated_session.handle,
           nonce: nil,
+          mint_jwt_access_token: downstream.mint_jwt_access_token,
         )
 
-        bearer = issued.access.to_bearer
+        bearer = issued.access.to_bearer(token_string: issued.access_token_string)
         bearer.refresh_token = rotated.format.to_s
         res.access_token = bearer
         res.id_token = issued.id_token_jwt if issued.id_token_jwt
@@ -231,28 +235,38 @@ module Himari
       # Mint an access token (and, for OIDC, an id_token JWT). Refresh tokens are handled
       # separately by each grant path: the authorization_code path mints a fresh one, while
       # the refresh path rotates the presented token in place.
-      private def issue_access_and_id(client:, claims:, lifetime:, openid:, session_handle:, nonce:)
-        access = AccessToken.make(client_id: client.id, claims: claims, session_handle: session_handle, lifetime: lifetime.access_token)
+      private def issue_access_and_id(client:, claims:, scopes:, lifetime:, openid:, session_handle:, nonce:, mint_jwt_access_token:)
+        access = AccessToken.make(client_id: client.id, claims: claims, scopes: scopes, session_handle: session_handle, lifetime: lifetime.access_token)
         @storage.put_token(access)
 
+        # Both the ID Token and a JWT access token are signed by the same key; resolve it once.
         signing_key = nil
-        id_token_jwt = nil
-        if openid
+        if openid || mint_jwt_access_token
           signing_key = @signing_key_provider.find(group: client.preferred_key_group, active: true)
           raise SigningKeyMissing unless signing_key
+        end
 
+        access_token_string = if mint_jwt_access_token
+          access.to_jwt(signing_key: signing_key, issuer: @issuer)
+        else
+          access.format.to_s
+        end
+
+        id_token_jwt = nil
+        if openid
           id_token_jwt = IdToken.new(
             claims: claims,
             client_id: client.id,
             nonce: nonce,
             signing_key: signing_key,
             issuer: @issuer,
-            access_token: access.format.to_s,
+            # at_hash binds the ID Token to the access token actually delivered (JWT or opaque).
+            access_token: access_token_string,
             lifetime: lifetime.id_token,
           ).to_jwt
         end
 
-        Issued.new(access: access, id_token_jwt: id_token_jwt, signing_key: signing_key)
+        Issued.new(access: access, access_token_string: access_token_string, id_token_jwt: id_token_jwt, signing_key: signing_key)
       end
     end
   end

--- a/himari/lib/himari/services/oidc_userinfo_endpoint.rb
+++ b/himari/lib/himari/services/oidc_userinfo_endpoint.rb
@@ -8,9 +8,12 @@ module Himari
   module Services
     class OidcUserinfoEndpoint
       # @param storage [Himari::Storages::Base]
+      # @param signing_key_provider [Himari::ProviderChain<Himari::SigningKey>] verifies RFC 9068
+      #   JWT access tokens; opaque tokens do not need it
       # @param logger [Logger]
-      def initialize(storage:, logger: nil)
+      def initialize(storage:, signing_key_provider: nil, logger: nil)
         @storage = storage
+        @signing_key_provider = signing_key_provider
         @logger = logger
       end
 
@@ -19,14 +22,15 @@ module Himari
       end
 
       def call(env)
-        Handler.new(storage: @storage, env: env, logger: @logger).response
+        Handler.new(storage: @storage, signing_key_provider: @signing_key_provider, env: env, logger: @logger).response
       end
 
       class Handler
         class InvalidToken < StandardError; end
 
-        def initialize(storage:, env:, logger:)
+        def initialize(storage:, env:, logger:, signing_key_provider: nil)
           @storage = storage
+          @signing_key_provider = signing_key_provider
           @env = env
           @logger = logger
         end
@@ -37,7 +41,7 @@ module Himari
 
           raise InvalidToken unless given_token
 
-          given_parsed_token = Himari::AccessToken.parse(given_token)
+          given_parsed_token = Himari::AccessToken.parse(given_token, signing_key_provider: @signing_key_provider)
 
           token = @storage.find_token(given_parsed_token.handle)
           raise InvalidToken unless token

--- a/himari/spec/himari/access_token_jwt_spec.rb
+++ b/himari/spec/himari/access_token_jwt_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'himari/access_token'
+require 'himari/access_token_jwt'
+require 'himari/signing_key'
+
+RSpec.describe Himari::AccessTokenJwt do
+  let(:t) { Time.now }
+  let(:pkey) { OpenSSL::PKey::RSA.new(Himari::Testing::TEST_RSA_KEY_PEM, '') }
+  let(:signing_key) { Himari::SigningKey.new(id: 'kid', pkey: pkey, inactive: false, group: 'kagi') }
+  let(:scopes) { %w(openid profile) }
+  let(:access) { Himari::AccessToken.make(client_id: 'testclient', claims: {sub: 'chihiro'}, scopes: scopes) }
+
+  subject(:jwt) do
+    described_class.new(access: access, claims: {sub: 'chihiro', email: 'c@test.invalid'}, client_id: 'testclient', signing_key: signing_key, issuer: 'https://test.invalid', time: t, lifetime: 456)
+  end
+
+  describe "#final_claims" do
+    specify do
+      # https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2 required claims, plus the IdP
+      # claims carried verbatim (same set as the ID Token), the granted scope, and hmat.
+      expect(jwt.final_claims).to eq(
+        sub: 'chihiro',
+        email: 'c@test.invalid',
+        iss: 'https://test.invalid',
+        aud: 'testclient',
+        client_id: 'testclient',
+        iat: t.to_i,
+        nbf: t.to_i,
+        exp: t.to_i + 456,
+        jti: access.handle,
+        scope: 'openid profile',
+        hmat: access.format.to_s,
+      )
+    end
+
+    # https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2.1 — scope is space-delimited.
+    context "when no scopes were granted" do
+      let(:scopes) { [] }
+      it "omits the scope claim" do
+        expect(jwt.final_claims).not_to have_key(:scope)
+      end
+    end
+
+    context "when the IdP claims have no sub" do
+      subject(:jwt) do
+        described_class.new(access: access, claims: {email: 'c@test.invalid'}, client_id: 'testclient', signing_key: signing_key, issuer: 'https://test.invalid', time: t, lifetime: 456)
+      end
+
+      it "fails closed rather than minting a non-conformant token" do
+        expect { jwt.final_claims }.to raise_error(described_class::MissingSubject)
+      end
+    end
+  end
+
+  # https://www.rfc-editor.org/rfc/rfc9068.html — assert the on-the-wire token meets the profile
+  # so a future change that drops a required claim/header fails here.
+  describe "RFC 9068 conformance of the minted token" do
+    let(:decoded) { JSON::JWT.decode(jwt.to_jwt, pkey) }
+
+    it "has the at+jwt typ header" do
+      expect(decoded.header[:typ]).to eq('at+jwt') # §2.1
+    end
+
+    it "is signed with an asymmetric alg (never none)" do
+      expect(decoded.header[:alg]).to eq('RS256') # §2.1: asymmetric, not 'none'
+      expect(decoded.header[:alg]).not_to eq('none')
+    end
+
+    it "carries every required claim" do
+      # §2.2 required: iss, exp, aud, sub, client_id, iat, jti
+      %i(iss exp aud sub client_id iat jti).each do |claim|
+        expect(decoded[claim]).not_to be_nil, "missing required claim #{claim}"
+      end
+      expect(decoded[:scope]).to eq('openid profile') # §2.2.1
+    end
+  end
+
+  describe "#to_jwt" do
+    let(:decoded) { JSON::JWT.decode(jwt.to_jwt, pkey) }
+
+    it "sets the RFC 9068 typ header and the signing key kid" do
+      expect(decoded.header[:typ]).to eq('at+jwt')
+      expect(decoded.header[:kid]).to eq('kid')
+    end
+
+    it "is verifiable with the signing key and carries hmat" do
+      expect(decoded[:sub]).to eq('chihiro')
+      expect(decoded['hmat']).to eq(access.format.to_s)
+    end
+  end
+end

--- a/himari/spec/himari/access_token_spec.rb
+++ b/himari/spec/himari/access_token_spec.rb
@@ -2,13 +2,17 @@
 
 require 'spec_helper'
 require 'himari/access_token'
+require 'himari/access_token_jwt'
+require 'himari/signing_key'
+require 'himari/provider_chain'
+require 'himari/item_providers/static'
 require 'base64'
 require 'digest/sha2'
 
 RSpec.describe Himari::AccessToken do
   describe "make roundtrip" do
     let(:now) { Time.now }
-    let(:authz) { double('authz', client_id: 'client', claims: {sub: 'chihiro'}, session_handle: 'sess', lifetime: double('lifetime', access_token: 123)) }
+    let(:authz) { double('authz', client_id: 'client', claims: {sub: 'chihiro'}, scopes: %w(openid profile), session_handle: 'sess', lifetime: double('lifetime', access_token: 123)) }
     subject { described_class.from_authz(authz) }
 
     before do
@@ -18,6 +22,7 @@ RSpec.describe Himari::AccessToken do
     specify do
       expect(subject.client_id).to eq('client')
       expect(subject.claims).to eq({sub: 'chihiro'})
+      expect(subject.scopes).to eq(%w(openid profile))
       expect(subject.expiry).to eq(now.to_i + 123)
       expect(subject.secret).to be_a(String)
     end
@@ -26,6 +31,52 @@ RSpec.describe Himari::AccessToken do
       parse = Himari::AccessToken.parse(subject.format.to_s)
       expect(parse.handle).to eq(subject.handle)
       expect(parse.secret).to eq(subject.secret)
+    end
+  end
+
+  describe ".parse with a JWT access token (RFC 9068)" do
+    let(:pkey) { OpenSSL::PKey::RSA.new(Himari::Testing::TEST_RSA_KEY_PEM, '') }
+    let(:signing_key) { Himari::SigningKey.new(id: 'kid', pkey: pkey, inactive: false, group: 'kagi') }
+    let(:signing_key_provider) { Himari::ProviderChain.new([Himari::ItemProviders::Static.new([signing_key])]) }
+
+    let(:access) { described_class.make(client_id: 'client', claims: {sub: 'chihiro'}) }
+    let(:jwt) do
+      Himari::AccessTokenJwt.new(access: access, claims: access.claims, client_id: 'client', signing_key: signing_key, issuer: 'https://test.invalid').to_jwt
+    end
+
+    it "verifies the signature and returns the embedded opaque token (hmat)" do
+      parsed = described_class.parse(jwt, signing_key_provider: signing_key_provider)
+      expect(parsed.handle).to eq(access.handle)
+      expect(parsed.secret).to eq(access.secret)
+    end
+
+    describe "#to_jwt round-trips through .parse" do
+      it "renders a JWT whose exp matches the token's own expiry and parses back to itself" do
+        str = access.to_jwt(signing_key: signing_key, issuer: 'https://test.invalid')
+        expect(JSON::JWT.decode(str, pkey)[:exp]).to eq(access.expiry)
+
+        parsed = described_class.parse(str, signing_key_provider: signing_key_provider)
+        expect(parsed.handle).to eq(access.handle)
+        expect(parsed.secret).to eq(access.secret)
+      end
+    end
+
+    it "requires a signing key provider to verify a JWT" do
+      expect { described_class.parse(jwt) }.to raise_error(Himari::TokenString::InvalidFormat)
+    end
+
+    it "rejects a JWT signed by an unknown key (kid)" do
+      empty_provider = Himari::ProviderChain.new([Himari::ItemProviders::Static.new([])])
+      expect { described_class.parse(jwt, signing_key_provider: empty_provider) }.to raise_error(Himari::TokenString::InvalidFormat)
+    end
+
+    it "rejects a JWT with a tampered signature" do
+      tampered = "#{jwt[0...-2]}XX"
+      expect { described_class.parse(tampered, signing_key_provider: signing_key_provider) }.to raise_error(Himari::TokenString::InvalidFormat)
+    end
+
+    it "rejects a non-JWT, non-opaque string" do
+      expect { described_class.parse('not a token', signing_key_provider: signing_key_provider) }.to raise_error(Himari::TokenString::InvalidFormat)
     end
   end
 end

--- a/himari/spec/himari/decisions/authorization_spec.rb
+++ b/himari/spec/himari/decisions/authorization_spec.rb
@@ -17,6 +17,23 @@ RSpec.describe Himari::Decisions::Authorization do
     end
   end
 
+  describe "#mint_jwt_access_token" do
+    it "defaults to false" do
+      expect(described_class.new.mint_jwt_access_token).to eq(false)
+    end
+
+    it "is settable by a rule and survives evolution" do
+      decision.mint_jwt_access_token = true
+      evolved = decision.evolve('rule')
+      expect(evolved.mint_jwt_access_token).to eq(true)
+    end
+
+    it "is surfaced in as_log" do
+      decision.mint_jwt_access_token = true
+      expect(decision.as_log[:mint_jwt_access_token]).to eq(true)
+    end
+  end
+
   describe "Context grant_type predicates" do
     it "treats :initial and nil as initial" do
       expect(described_class::Context.new(grant_type: :initial).initial?).to eq(true)

--- a/himari/spec/himari/services/downstream_authorization_spec.rb
+++ b/himari/spec/himari/services/downstream_authorization_spec.rb
@@ -53,6 +53,21 @@ RSpec.describe Himari::Services::DownstreamAuthorization do
     end
   end
 
+  describe "mint_jwt_access_token" do
+    it "defaults to false and carries a rule's opt-in onto the Result" do
+      expect(described_class.new(session: session_data, client: client, request: rack_request, requested_scopes: requested_scopes, authz_rules: [
+        Himari::Rule.new(name: 'allow', block: proc { |_c, d| d.allow! }),
+      ]).perform.mint_jwt_access_token).to eq(false)
+
+      expect(described_class.new(session: session_data, client: client, request: rack_request, requested_scopes: requested_scopes, authz_rules: [
+        Himari::Rule.new(name: 'allow', block: proc { |_c, d|
+          d.mint_jwt_access_token = true
+          d.allow!
+        }),
+      ]).perform.mint_jwt_access_token).to eq(true)
+    end
+  end
+
   describe "scope filtering" do
     it "filters the requested scopes through the client's allow-list and exposes them to rules" do
       expect(client).to receive(:filter_scopes).with(%w(openid profile email)).and_return(%w(openid profile))

--- a/himari/spec/himari/services/oidc_token_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_token_endpoint_spec.rb
@@ -249,6 +249,31 @@ RSpec.describe Himari::Services::OidcTokenEndpoint do
       end
     end
 
+    context "with mint_jwt_access_token (RFC 9068)" do
+      let(:authz) { Himari::AuthorizationCode.make(client_id: 'clientid', claims: {sub: 'chihiro'}, redirect_uri: 'https://rp.invalid/cb', openid: scope_openid, scopes: %w(openid profile), mint_jwt_access_token: true, lifetime: lifetime_value) }
+
+      it "delivers a signed JWT access token that still validates against storage via hmat" do
+        post '/oidc/token', 'grant_type' => 'authorization_code', 'code' => authz.code, 'redirect_uri' => 'https://rp.invalid/cb'
+        expect(last_response.status).to eq(200)
+        body = JSON.parse(last_response.body, symbolize_names: true)
+
+        at = body[:access_token]
+        # verifiable by the signing key, RFC 9068 typ, and carries the IdP claims + granted scope
+        decoded = JSON::JWT.decode(at, pkey)
+        expect(decoded.header[:typ]).to eq('at+jwt')
+        expect(decoded[:sub]).to eq('chihiro')
+        expect(decoded[:client_id]).to eq('clientid')
+        expect(decoded[:scope]).to eq('openid profile')
+
+        # Himari authenticates it through the embedded opaque token
+        allow(signing_key_provider).to receive(:find).with(id: 'kid').and_return(signing_key)
+        parsed = Himari::AccessToken.parse(at, signing_key_provider: signing_key_provider)
+        token = storage.find_token(parsed.handle)
+        expect(token).not_to be_nil
+        expect(token.verify_secret!(parsed.secret)).to eq(true)
+      end
+    end
+
     context "using openid scope" do
       let(:scope_openid) { true }
 

--- a/himari/spec/himari/services/oidc_userinfo_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_userinfo_endpoint_spec.rb
@@ -4,17 +4,25 @@ require 'spec_helper'
 require 'himari/services/oidc_userinfo_endpoint'
 require 'himari/storages/memory'
 require 'himari/access_token'
+require 'himari/access_token_jwt'
+require 'himari/signing_key'
+require 'himari/provider_chain'
+require 'himari/item_providers/static'
 
 RSpec.describe Himari::Services::OidcUserinfoEndpoint do
   include Rack::Test::Methods
 
   let(:storage) { Himari::Storages::Memory.new }
 
+  let(:pkey) { OpenSSL::PKey::RSA.new(Himari::Testing::TEST_RSA_KEY_PEM, '') }
+  let(:signing_key) { Himari::SigningKey.new(id: 'kid', pkey: pkey, inactive: false, group: 'kagi') }
+  let(:signing_key_provider) { Himari::ProviderChain.new([Himari::ItemProviders::Static.new([signing_key])]) }
+
   let(:token) { Himari::AccessToken.make(client_id: 'clientid', claims: {sub: 'chihiro'}) }
   let(:bearer) { nil }
   let(:logger) { Rack::NullLogger.new(nil) }
 
-  let(:app) { described_class.new(storage: storage, logger: logger) }
+  let(:app) { described_class.new(storage: storage, signing_key_provider: signing_key_provider, logger: logger) }
 
   before do
     storage.put_token(token)
@@ -71,6 +79,34 @@ RSpec.describe Himari::Services::OidcUserinfoEndpoint do
         aud: 'clientid',
         sub: 'chihiro',
       )
+    end
+  end
+
+  context "with a valid RFC 9068 JWT access token" do
+    let(:jwt) do
+      Himari::AccessTokenJwt.new(access: token, claims: token.claims, client_id: 'clientid', signing_key: signing_key, issuer: 'https://test.invalid').to_jwt
+    end
+    let(:bearer) { "Bearer #{jwt}" }
+
+    it "verifies the signature, resolves hmat, and returns metadata" do
+      get '/oidc/userinfo'
+      expect(last_response).to be_ok
+      body = JSON.parse(last_response.body, symbolize_names: true)
+      expect(body).to eq(aud: 'clientid', sub: 'chihiro')
+    end
+  end
+
+  context "with a JWT access token signed by an unknown key" do
+    let(:other_pkey) { OpenSSL::PKey::RSA.generate(2048) }
+    let(:other_key) { Himari::SigningKey.new(id: 'kid', pkey: other_pkey, inactive: false, group: 'kagi') }
+    let(:jwt) do
+      Himari::AccessTokenJwt.new(access: token, claims: token.claims, client_id: 'clientid', signing_key: other_key, issuer: 'https://test.invalid').to_jwt
+    end
+    let(:bearer) { "Bearer #{jwt}" }
+
+    it "returns 401" do
+      get '/oidc/userinfo'
+      expect(last_response.status).to eq(401)
     end
   end
 end


### PR DESCRIPTION
Issue access tokens as signed RFC 9068 JWTs (typ=at+jwt) so relying parties can validate and read claims without a userinfo round-trip, while Himari keeps validating them as before. The opt-in is per authorization: an authz rule sets decision.mint_jwt_access_token, which rides the grant (AuthorizationCode) and is recomputed on refresh.

The JWT embeds the opaque token in an hmat claim (Himari's existing magic header doubling as the claim name). AccessToken.parse detects a JWT, verifies its signature against the signing keys, then extracts hmat and validates the secret against storage exactly as for an opaque token — so the opaque secret stays the real authenticator and the signature is an additional, self-contained guarantee for RPs. Validation failures all normalise to TokenString::InvalidFormat.

- Minting is shared with the ID Token: JwtToken holds the common claim derivation and signing; IdToken and AccessTokenJwt subclass it. The access token therefore exposes the same claim set as the ID Token, plus the RFC 9068 registered claims (client_id, jti, iss/aud/iat/exp) and the granted scope.
- AccessToken converts itself via #to_jwt; the token endpoint never builds the JWT directly. exp is tied to the token's own expiry so both forms expire together. at_hash binds the ID Token to whichever access token is actually delivered.
- Conformance is enforced, not incidental: AccessTokenJwt fails closed (MissingSubject) if a misconfigured allowed_claims strips sub, and a spec asserts the typ header, asymmetric alg, every required claim, and scope on the minted token.
- AccessToken gains a scopes member, threaded from the grant and serialised through storage (older records default to empty); the userinfo endpoint gains the signing key provider to verify JWTs.