### PR TITLE
metadata: extensible scopes_supported & claims_supported

### DIFF
--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -296,6 +296,8 @@ module Himari
         issuer: config.issuer,
         registration_endpoint: dynamic_clients_enabled? ? "#{config.issuer}/public/oidc/register" : nil,
         client_id_metadata_document_supported: metadata_clients_enabled?,
+        scopes_supported: config.scopes_supported,
+        claims_supported: config.claims_supported,
       ).call(env)
     end
     # OpenID Connect Discovery 1.0

--- a/himari/lib/himari/config.rb
+++ b/himari/lib/himari/config.rb
@@ -7,7 +7,7 @@ require 'himari/log_line'
 
 module Himari
   class Config
-    def initialize(issuer:, storage:, providers: [], log_output: $stdout, log_level: Logger::INFO, preserve_rack_logger: false, custom_templates: {}, custom_messages: {}, release_fragment: nil)
+    def initialize(issuer:, storage:, providers: [], log_output: $stdout, log_level: Logger::INFO, preserve_rack_logger: false, custom_templates: {}, custom_messages: {}, release_fragment: nil, scopes_supported: [], claims_supported: [])
       @issuer = issuer
       @providers = providers
       @storage = storage
@@ -19,9 +19,12 @@ module Himari
       @custom_messages = custom_messages
       @custom_templates = custom_templates
       @release_fragment = release_fragment
+
+      @scopes_supported = scopes_supported
+      @claims_supported = claims_supported
     end
 
-    attr_reader :issuer, :providers, :storage, :preserve_rack_logger, :custom_messages, :custom_templates, :release_fragment
+    attr_reader :issuer, :providers, :storage, :preserve_rack_logger, :custom_messages, :custom_templates, :release_fragment, :scopes_supported, :claims_supported
 
     def logger
       @logger ||= Logger.new(@log_output).tap do |l|

--- a/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
+++ b/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
@@ -3,14 +3,22 @@
 module Himari
   module Services
     class OidcProviderMetadataEndpoint
+      # Scopes and claims Himari always advertises; configured values are merged on top.
+      DEFAULT_SCOPES_SUPPORTED = %w(openid refresh_token).freeze
+      DEFAULT_CLAIMS_SUPPORTED = %w(sub iss iat nbf exp).freeze
+
       # @param signing_key_provider [Himari::ProviderChain<Himari::SigningKey>]
       # @param registration_endpoint [String, nil] advertised when Dynamic Client Registration is enabled
       # @param client_id_metadata_document_supported [Boolean] advertised when OAuth Client ID Metadata Document support is enabled
-      def initialize(signing_key_provider:, issuer:, registration_endpoint: nil, client_id_metadata_document_supported: false)
+      # @param scopes_supported [Array<String>] extra scopes to advertise alongside the defaults
+      # @param claims_supported [Array<String>] extra claims to advertise alongside the defaults
+      def initialize(signing_key_provider:, issuer:, registration_endpoint: nil, client_id_metadata_document_supported: false, scopes_supported: [], claims_supported: [])
         @signing_key_provider = signing_key_provider
         @issuer = issuer
         @registration_endpoint = registration_endpoint
         @client_id_metadata_document_supported = client_id_metadata_document_supported
+        @scopes_supported = scopes_supported
+        @claims_supported = claims_supported
       end
 
       def app
@@ -18,17 +26,19 @@ module Himari
       end
 
       def call(env)
-        Handler.new(signing_key_provider: @signing_key_provider, issuer: @issuer, registration_endpoint: @registration_endpoint, client_id_metadata_document_supported: @client_id_metadata_document_supported, env: env).response
+        Handler.new(signing_key_provider: @signing_key_provider, issuer: @issuer, registration_endpoint: @registration_endpoint, client_id_metadata_document_supported: @client_id_metadata_document_supported, scopes_supported: @scopes_supported, claims_supported: @claims_supported, env: env).response
       end
 
       class Handler
         class InvalidToken < StandardError; end
 
-        def initialize(signing_key_provider:, issuer:, env:, registration_endpoint: nil, client_id_metadata_document_supported: false)
+        def initialize(signing_key_provider:, issuer:, env:, registration_endpoint: nil, client_id_metadata_document_supported: false, scopes_supported: [], claims_supported: [])
           @signing_key_provider = signing_key_provider
           @issuer = issuer
           @registration_endpoint = registration_endpoint
           @client_id_metadata_document_supported = client_id_metadata_document_supported
+          @scopes_supported = scopes_supported
+          @claims_supported = claims_supported
           @env = env
         end
 
@@ -42,14 +52,14 @@ module Himari
             jwks_uri: "#{@issuer}/public/jwks",
             registration_endpoint: @registration_endpoint,
             client_id_metadata_document_supported: @client_id_metadata_document_supported ? true : nil,
-            scopes_supported: %w(openid refresh_token),
+            scopes_supported: (DEFAULT_SCOPES_SUPPORTED + @scopes_supported).uniq,
             response_types_supported: ['code'], # violation: dynamic OpenID Provider MUST support code, id_token, token+id_token
             grant_types_supported: %w(authorization_code refresh_token),
             token_endpoint_auth_methods_supported: %w(client_secret_basic client_secret_post none),
             code_challenge_methods_supported: %w(S256 plain),
             subject_types_supported: ['public'],
             id_token_signing_alg_values_supported: signing_keys.map(&:alg).uniq.sort,
-            claims_supported: %w(sub iss iat nbf exp),
+            claims_supported: (DEFAULT_CLAIMS_SUPPORTED + @claims_supported).uniq,
           }.compact
         end
 

--- a/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
+++ b/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
@@ -42,7 +42,7 @@ module Himari
             jwks_uri: "#{@issuer}/public/jwks",
             registration_endpoint: @registration_endpoint,
             client_id_metadata_document_supported: @client_id_metadata_document_supported ? true : nil,
-            scopes_supported: %w(openid),
+            scopes_supported: %w(openid refresh_token),
             response_types_supported: ['code'], # violation: dynamic OpenID Provider MUST support code, id_token, token+id_token
             grant_types_supported: %w(authorization_code refresh_token),
             token_endpoint_auth_methods_supported: %w(client_secret_basic client_secret_post none),

--- a/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
   let(:signing_key_provider) { double('chain', collect: keys) }
   let(:registration_endpoint) { nil }
   let(:client_id_metadata_document_supported) { false }
-  let(:app) { described_class.new(signing_key_provider: signing_key_provider, issuer: 'https://test.invalid', registration_endpoint: registration_endpoint, client_id_metadata_document_supported: client_id_metadata_document_supported) }
+  let(:scopes_supported) { [] }
+  let(:claims_supported) { [] }
+  let(:app) { described_class.new(signing_key_provider: signing_key_provider, issuer: 'https://test.invalid', registration_endpoint: registration_endpoint, client_id_metadata_document_supported: client_id_metadata_document_supported, scopes_supported: scopes_supported, claims_supported: claims_supported) }
 
   context "with non-GET request" do
     it "returns 404" do
@@ -68,6 +70,39 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
           get '/.well-known/openid-configuration'
           body = JSON.parse(last_response.body, symbolize_names: true)
           expect(body[:client_id_metadata_document_supported]).to eq(true)
+        end
+      end
+
+      context "without additional scopes/claims" do
+        it "advertises the default scopes and claims" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body[:scopes_supported]).to eq(%w(openid refresh_token))
+          expect(body[:claims_supported]).to eq(%w(sub iss iat nbf exp))
+        end
+      end
+
+      context "with additional scopes/claims" do
+        let(:scopes_supported) { %w(profile email) }
+        let(:claims_supported) { %w(name email) }
+
+        it "merges them with the defaults" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body[:scopes_supported]).to eq(%w(openid refresh_token profile email))
+          expect(body[:claims_supported]).to eq(%w(sub iss iat nbf exp name email))
+        end
+      end
+
+      context "with additional scopes/claims overlapping the defaults" do
+        let(:scopes_supported) { %w(openid profile) }
+        let(:claims_supported) { %w(sub name) }
+
+        it "de-duplicates while preserving order" do
+          get '/.well-known/openid-configuration'
+          body = JSON.parse(last_response.body, symbolize_names: true)
+          expect(body[:scopes_supported]).to eq(%w(openid refresh_token profile))
+          expect(body[:claims_supported]).to eq(%w(sub iss iat nbf exp name))
         end
       end
     end


### PR DESCRIPTION
Config now accepts scopes_supported and claims_supported, merged on top of the values Himari always advertises (openid/refresh_token and sub/iss/iat/nbf/exp). Lets deployments advertise extra scopes and the custom claims emitted via ClaimsRule without re-listing the built-ins; overlapping entries are de-duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)