### PR TITLE
implement RFC 9207 issuer identification

### DIFF
--- a/himari/CHANGELOG.md
+++ b/himari/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Enhancements
+
+- Authorization Server Issuer Identification (RFC 9207): the authorization endpoint now returns the `iss` parameter in all authorization responses (success and redirected errors), and discovery metadata advertises `authorization_response_iss_parameter_supported`
+
 ## [0.6.0] - 2026-06-03
 
 ### Enhancements

--- a/himari/lib/himari/app.rb
+++ b/himari/lib/himari/app.rb
@@ -200,6 +200,7 @@ module Himari
           authz: authz,
           client: client,
           storage: config.storage,
+          issuer: config.issuer,
           consent: consent,
           logger: logger,
         ).call(env)

--- a/himari/lib/himari/rack_oauth2_ext.rb
+++ b/himari/lib/himari/rack_oauth2_ext.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rack/oauth2'
+
+module Himari
+  # RFC 9207 Authorization Server Issuer Identification, implemented as extensions to rack-oauth2.
+  #
+  # rack-oauth2 builds the grant redirect from the response object handed to the authorization
+  # endpoint block, but constructs and finishes error redirects internally (Authorize#_call rescues
+  # and calls e.finish), so those error objects are out of reach. Instead we teach rack-oauth2 to
+  # carry an `iss` through both: the issuer is set on the request/response, and the response classes
+  # merge it into their protocol_params (the parameters rack-oauth2 places on the redirect). Errors
+  # copy it from the request the same way they copy state/redirect_uri.
+  module RackOAuth2Ext
+    # Carried by the grant response; always emitted because the grant is always a redirect.
+    # Prepended onto the base response so every response type (Code::Response calls super) gains the
+    # `iss` accessor, including the response objects the loaded extensions hand to the endpoint block.
+    module IssuerParam
+      attr_accessor :iss
+
+      def protocol_params
+        super.merge(iss:)
+      end
+    end
+
+    # Carried by error responses, but only emitted when the error is actually delivered to the
+    # client via redirect. RFC 9207 covers authorization responses, not the JSON error bodies
+    # rack-oauth2 returns directly to the user agent when there is no trusted redirect_uri.
+    module ErrorIssuerParam
+      attr_accessor :iss
+
+      def protocol_params
+        redirect? ? super.merge(iss:) : super
+      end
+    end
+
+    # rack-oauth2 stamps state and redirect_uri from the request onto every error it raises; thread
+    # the issuer along the same path so ErrorIssuerParam has a value to emit.
+    module RequestIssuer
+      attr_accessor :iss
+
+      private def error!(klass, error, description, options)
+        super
+      rescue Rack::OAuth2::Server::Abstract::Error => e
+        e.iss = iss if e.respond_to?(:iss=)
+        raise e
+      end
+    end
+
+    Rack::OAuth2::Server::Authorize::Response.prepend(IssuerParam)
+    Rack::OAuth2::Server::Authorize::Request.prepend(RequestIssuer)
+    [
+      Rack::OAuth2::Server::Authorize::BadRequest,
+      Rack::OAuth2::Server::Authorize::ServerError,
+      Rack::OAuth2::Server::Authorize::TemporarilyUnavailable,
+    ].each { |klass| klass.prepend(ErrorIssuerParam) }
+  end
+end

--- a/himari/lib/himari/services/oidc_authorization_endpoint.rb
+++ b/himari/lib/himari/services/oidc_authorization_endpoint.rb
@@ -4,6 +4,8 @@ require 'rack/oauth2'
 require 'digest/sha2'
 require 'openid_connect'
 
+require 'himari/rack_oauth2_ext'
+
 module Himari
   module Services
     class OidcAuthorizationEndpoint
@@ -26,12 +28,14 @@ module Himari
       # @param authz [Himari::AuthorizationCode] pending (unpersisted) authz data
       # @param client [Himari::ClientRegistration]
       # @param storage [Himari::Storages::Base]
+      # @param issuer [String] issuer identifier, returned to the client as the RFC 9207 `iss` parameter
       # @param consent [:approve, :deny, nil] the user's consent decision (nil = not yet asked)
       # @param logger [Logger]
-      def initialize(authz:, client:, storage:, consent: nil, logger: nil)
+      def initialize(authz:, client:, storage:, issuer:, consent: nil, logger: nil)
         @authz = authz
         @client = client
         @storage = storage
+        @issuer = issuer
         @consent = consent
         @logger = logger
       end
@@ -47,6 +51,11 @@ module Himari
 
       def app(env)
         Rack::OAuth2::Server::Authorize.new do |req, res|
+          # RFC 9207: hand the issuer to rack-oauth2 so both the grant response and any error it
+          # redirects back to the client carry the `iss` parameter (see Himari::RackOAuth2Ext).
+          req.iss = @issuer
+          res.iss = @issuer
+
           # sanity check
           unless @client.id == req.client_id
             @logger&.warn(Himari::LogLine.new('OidcAuthorizationEndpoint: @client.id != req.client_id', req: env['himari.request_as_log'], known_client: @client.id, given_client: req.client_id))

--- a/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
+++ b/himari/lib/himari/services/oidc_provider_metadata_endpoint.rb
@@ -60,6 +60,7 @@ module Himari
             subject_types_supported: ['public'],
             id_token_signing_alg_values_supported: signing_keys.map(&:alg).uniq.sort,
             claims_supported: (DEFAULT_CLAIMS_SUPPORTED + @claims_supported).uniq,
+            authorization_response_iss_parameter_supported: true, # RFC 9207
           }.compact
         end
 

--- a/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_authorization_endpoint_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
   let(:client) { Himari::ClientRegistration.new(id: 'clientid', redirect_uris:, confidential: false, require_pkce:, skip_consent:) }
   let(:storage) { Himari::Storages::Memory.new }
   let(:logger) { Rack::NullLogger.new(nil) }
+  let(:issuer) { 'https://test.invalid' }
 
-  let(:app) { described_class.new(authz: authz, client: client, storage: storage, consent: consent, logger: logger) }
+  let(:app) { described_class.new(authz: authz, client: client, storage: storage, issuer: issuer, consent: consent, logger: logger) }
 
   context "with invalid clientid combination" do
     it "returns 400" do
@@ -37,6 +38,7 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
       expect(last_response.status).to eq(302)
       fragment = Addressable::URI.parse(last_response.headers['location']).fragment
       expect(fragment).to include('error=unsupported_response_type')
+      expect(fragment).to include('iss=https%3A%2F%2Ftest.invalid')
     end
   end
 
@@ -73,6 +75,7 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
       query = Addressable::URI.parse(last_response.headers['location']).query_values
       expect(query['state']).to eq('x')
       expect(query['code']).to be_a(String)
+      expect(query['iss']).to eq('https://test.invalid')
 
       authz = storage.find_authorization(query['code'])
       expect(authz).to be_a(Himari::AuthorizationCode)
@@ -229,6 +232,7 @@ RSpec.describe Himari::Services::OidcAuthorizationEndpoint do
         query = Addressable::URI.parse(last_response.headers['location']).query_values
         expect(query['error']).to eq('access_denied')
         expect(query['state']).to eq('x')
+        expect(query['iss']).to eq('https://test.invalid')
       end
     end
 

--- a/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
+++ b/himari/spec/himari/services/oidc_provider_metadata_endpoint_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Himari::Services::OidcProviderMetadataEndpoint do
         body = JSON.parse(last_response.body, symbolize_names: true)
 
         expect(body[:id_token_signing_alg_values_supported]).to eq(%w(RS256))
+        expect(body[:authorization_response_iss_parameter_supported]).to eq(true)
       end
 
       context "without dynamic client registration" do

--- a/omniauth-himari/CHANGELOG.md
+++ b/omniauth-himari/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Enhancements
+
+- Validate the Authorization Server Issuer Identification `iss` parameter (RFC 9207) on the authorization response, defending against mix-up attacks; controlled by the new `verify_iss` option (default enabled)
+
 ## [0.3.0] - 2026-06-03
 
 ### Enhancements

--- a/omniauth-himari/README.md
+++ b/omniauth-himari/README.md
@@ -22,6 +22,7 @@ use OmniAuth::Builder do
 
     # verify_options: { ... } # JWT.decode verify options override
     # verify_at_hash: true, # Verify at_hash returned in ID token
+    # verify_iss: true, # Verify RFC 9207 iss parameter on the authorization response
 
     # use_userinfo: false # force use of userinfo endpoint for raw_info
     # jwks_url: '...' # JWKs url to override (default=/public/jwks)

--- a/omniauth-himari/lib/omniauth/strategies/himari.rb
+++ b/omniauth-himari/lib/omniauth/strategies/himari.rb
@@ -24,6 +24,7 @@ module OmniAuth
 
       option :verify_options, {}
       option :verify_at_hash, true
+      option :verify_iss, true
 
       option :use_userinfo, false
 
@@ -48,6 +49,19 @@ module OmniAuth
 
         raise ConfigurationError, "client_id and client_secret is required" unless options.client_id && options.client_secret
         raise ConfigurationError, "site is required" unless options.client_options.site
+
+        super
+      end
+
+      # RFC 9207: validate the authorization server's issuer identifier returned alongside the
+      # authorization response before exchanging the code, defending against mix-up attacks.
+      def callback_phase
+        if options.verify_iss
+          iss = request.params['iss']
+          if iss && iss != options.site
+            return fail!(:issuer_mismatch, VerificationError.new("iss mismatch: #{iss.inspect} != #{options.site.inspect}"))
+          end
+        end
 
         super
       end

--- a/omniauth-himari/spec/omniauth/himari_spec.rb
+++ b/omniauth-himari/spec/omniauth/himari_spec.rb
@@ -1,11 +1,63 @@
 # frozen_string_literal: true
 
-RSpec.describe Omniauth::Himari do
+RSpec.describe OmniAuth::Strategies::Himari do
   it "has a version number" do
     expect(Omniauth::Himari::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe "#callback_phase (RFC 9207 issuer validation)" do
+    subject(:strategy) { described_class.new(app, 'https://idp.invalid', client_id: 'cid', client_secret: 'secret', **options) }
+
+    let(:app) { ->(_env) { [200, {}, ['ok']] } }
+    let(:options) { {} }
+
+    before do
+      allow(strategy).to receive(:request).and_return(double('request', params: params))
+      # An empty session makes the upstream OAuth2 state check fail (omniauth.state is absent),
+      # so a request that passes the issuer gate stops at :csrf_detected without any token exchange.
+      allow(strategy).to receive(:session).and_return({})
+      allow(strategy).to receive(:fail!)
+    end
+
+    context "when iss matches the configured site" do
+      let(:params) { {'iss' => 'https://idp.invalid', 'code' => 'c', 'state' => 's'} }
+
+      it "passes the issuer gate and proceeds to the standard callback" do
+        strategy.callback_phase
+        expect(strategy).not_to have_received(:fail!).with(:issuer_mismatch, anything)
+        expect(strategy).to have_received(:fail!).with(:csrf_detected, anything)
+      end
+    end
+
+    context "when iss is absent" do
+      let(:params) { {'code' => 'c', 'state' => 's'} }
+
+      it "passes the issuer gate (backward compatible with servers not emitting iss)" do
+        strategy.callback_phase
+        expect(strategy).not_to have_received(:fail!).with(:issuer_mismatch, anything)
+        expect(strategy).to have_received(:fail!).with(:csrf_detected, anything)
+      end
+    end
+
+    context "when iss does not match the configured site" do
+      let(:params) { {'iss' => 'https://evil.invalid', 'code' => 'c', 'state' => 's'} }
+
+      it "rejects the response before exchanging the code" do
+        strategy.callback_phase
+        expect(strategy).to have_received(:fail!).with(:issuer_mismatch, an_instance_of(described_class::VerificationError))
+        expect(strategy).not_to have_received(:fail!).with(:csrf_detected, anything)
+      end
+    end
+
+    context "when verify_iss is disabled" do
+      let(:options) { {verify_iss: false} }
+      let(:params) { {'iss' => 'https://evil.invalid', 'code' => 'c', 'state' => 's'} }
+
+      it "skips issuer validation" do
+        strategy.callback_phase
+        expect(strategy).not_to have_received(:fail!).with(:issuer_mismatch, anything)
+        expect(strategy).to have_received(:fail!).with(:csrf_detected, anything)
+      end
+    end
   end
 end

--- a/omniauth-himari/spec/spec_helper.rb
+++ b/omniauth-himari/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "omniauth/himari"
+require "omniauth-himari"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Authorization Server Issuer Identification (RFC 9207) lets clients detect mix-up attacks by confirming which AS produced an authorization response. Himari now returns the `iss` parameter, advertises support, and omniauth-himari validates it.

- himari: the authorization endpoint emits `iss` on every response delivered to the client (the grant and any error redirected back to redirect_uri). rack-oauth2 builds error redirects internally, with no object to hook, so Himari::RackOAuth2Ext prepends the issuer into the request/response/error protocol_params rather than rewriting the Location header. Errors returned directly to the user agent (no trusted redirect_uri) intentionally omit `iss`.
- himari: discovery and RFC 8414 metadata advertise authorization_response_iss_parameter_supported
- omniauth-himari: validate the `iss` parameter on the authorization response via the new `verify_iss` option (default enabled). A mismatch is rejected before the code exchange; a missing `iss` is allowed so older servers keep working.
- omniauth-himari: fix spec_helper requiring a non-existent path, which prevented the suite from loading at all